### PR TITLE
透明度が0xFFでないpixelを無視して画像比較するComparatorの追加

### DIFF
--- a/pitalium/src/main/java/com/htmlhifive/pitalium/image/model/CompareOption.java
+++ b/pitalium/src/main/java/com/htmlhifive/pitalium/image/model/CompareOption.java
@@ -25,6 +25,10 @@ public enum CompareOption {
 	 */
 	STRICT,
 	/**
+	 * 透明度が0xFF以外のpixelは無視して比較します。
+	 */
+	IGNORE_CLEAR_PIXELS,
+	/**
 	 * 画像の余白部分を無視して比較します。
 	 */
 	IGNORE_BLANK_SPACE;

--- a/pitalium/src/main/java/com/htmlhifive/pitalium/image/util/IgnoringClearPixelsImageComparator.java
+++ b/pitalium/src/main/java/com/htmlhifive/pitalium/image/util/IgnoringClearPixelsImageComparator.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2015-2016 NS Solutions Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.htmlhifive.pitalium.image.util;
+
+import java.awt.Point;
+import java.awt.image.BufferedImage;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * 透明度が0xFFでないピクセルは無視して画像比較
+ */
+class IgnoringClearPixelsImageComparator extends ImageComparator {
+
+	private static final Logger LOG = LoggerFactory.getLogger(IgnoringClearPixelsImageComparator.class);
+
+	/**
+	 * 0xFFの透明度を表す定数.
+	 */
+	private static final int ALPHA_FF = 0xFF000000;
+
+	/**
+	 * ARGB（32bit）から透明度のみを取得するためのマスキング定数.
+	 */
+	private static final int ALPHA_MASK = 0xFF000000;
+
+	/**
+	 * コンストラクタ
+	 */
+	IgnoringClearPixelsImageComparator() {
+	}
+
+	@Override
+	protected List<Point> compare(BufferedImage image1, BufferedImage image2, int offsetX, int offsetY) {
+		LOG.trace("[Compare] image1[w: {}, h: {}], image2[w: {}, h: {}], offset: ({}, {})", image1.getWidth(),
+				image1.getHeight(), image2.getWidth(), image2.getHeight(), offsetX, offsetY);
+		int width = Math.min(image1.getWidth(), image2.getWidth());
+		int height = Math.min(image1.getHeight(), image2.getHeight());
+
+		int[] rgb1 = ImageUtils.getRGB(image1, width, height);
+		int[] rgb2 = ImageUtils.getRGB(image2, width, height);
+
+		List<Point> diffPoints = new ArrayList<Point>();
+		for (int i = 0, length = rgb1.length; i < length; i++) {
+
+			if (isClear(rgb1[i]) || isClear(rgb2[i])) {
+				LOG.trace("[Compare] is clear. #{} or #{}", Integer.toHexString(rgb1[i]), Integer.toHexString(rgb2[i]));
+				continue;
+			}
+
+			if (rgb1[i] != rgb2[i]) {
+				int x = (i % width) + offsetX;
+				int y = (i / width) + offsetY;
+
+				Point diffPoint = new Point(x, y);
+				diffPoints.add(diffPoint);
+				LOG.trace("[Compare] Diff found ({}, {}). #{} <=> #{}", diffPoint.x, diffPoint.y,
+						Integer.toHexString(rgb1[i]), Integer.toHexString(rgb2[i]));
+			}
+		}
+
+		if (!diffPoints.isEmpty()) {
+			LOG.debug("[Compare] {} diff found.", diffPoints.size());
+		}
+		return diffPoints;
+
+	}
+
+	/**
+	 * 透明度が0xFFかどうか
+	 *
+	 * @param argb pixel
+	 * @return 透明度が0xFFであればtrue, そうでなければ false
+	 */
+	private boolean isClear(int argb) {
+		return (argb & ALPHA_MASK) != ALPHA_FF;
+	}
+
+}

--- a/pitalium/src/main/java/com/htmlhifive/pitalium/image/util/ImageComparatorFactory.java
+++ b/pitalium/src/main/java/com/htmlhifive/pitalium/image/util/ImageComparatorFactory.java
@@ -15,6 +15,8 @@
  */
 package com.htmlhifive.pitalium.image.util;
 
+import java.util.Arrays;
+
 import com.htmlhifive.pitalium.image.model.CompareOption;
 
 /**
@@ -46,7 +48,10 @@ public final class ImageComparatorFactory {
 	 * @return ImageComparatorオブジェクト
 	 */
 	public ImageComparator getImageComparator(CompareOption[] options) {
-		// TODO implements ImageComparator for each options.
+		if (options != null && options.length > 0
+				&& Arrays.asList(options).contains(CompareOption.IGNORE_CLEAR_PIXELS)) {
+			return new IgnoringClearPixelsImageComparator();
+		}
 		return new DefaultImageComparator();
 	}
 }

--- a/pitalium/src/test/java/com/htmlhifive/pitalium/image/util/IgnoringClearPixelsImageComparatorTest.java
+++ b/pitalium/src/test/java/com/htmlhifive/pitalium/image/util/IgnoringClearPixelsImageComparatorTest.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright (C) 2015-2016 NS Solutions Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.htmlhifive.pitalium.image.util;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.image.BufferedImage;
+import java.util.Comparator;
+import java.util.Random;
+import java.util.Set;
+import java.util.TreeSet;
+
+import javax.imageio.ImageIO;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import com.htmlhifive.pitalium.common.exception.TestRuntimeException;
+import com.htmlhifive.pitalium.image.model.DiffPoints;
+
+public class IgnoringClearPixelsImageComparatorTest {
+
+	@Rule
+	public ExpectedException expectedException = ExpectedException.none();
+
+	/**
+	 * メソッド引数チェック。image1がnullの場合、TestRuntimeException。
+	 */
+	@Test
+	public void testCompare_illegalArgument_image1_null() throws Exception {
+		BufferedImage image = ImageIO.read(getClass().getResource("hifive_logo.png"));
+		Rectangle rectangle = new Rectangle(0, 0, image.getWidth(), image.getHeight());
+
+		expectedException.expect(TestRuntimeException.class);
+		new IgnoringClearPixelsImageComparator().compare(null, null, image, rectangle);
+	}
+
+	/**
+	 * メソッド引数チェック。image2がnullの場合、TestRuntimeException。
+	 */
+	@Test
+	public void testCompare_illegalArgument_image2_null() throws Exception {
+		BufferedImage image = ImageIO.read(getClass().getResource("hifive_logo.png"));
+		Rectangle rectangle = new Rectangle(0, 0, image.getWidth(), image.getHeight());
+
+		expectedException.expect(TestRuntimeException.class);
+		new IgnoringClearPixelsImageComparator().compare(image, rectangle, null, null);
+	}
+
+	/**
+	 * 同じ画像と同じ領域を比較 => 成功
+	 */
+	@Test
+	public void testCompare() throws Exception {
+		BufferedImage image = ImageIO.read(getClass().getResource("hifive_logo.png"));
+		Rectangle rectangle = new Rectangle(0, 0, image.getWidth(), image.getHeight());
+		DiffPoints result = new IgnoringClearPixelsImageComparator().compare(image, rectangle, image, rectangle);
+
+		assertThat(result.isSucceeded(), is(true));
+	}
+
+	/**
+	 * 違う画像を比較する => 失敗
+	 */
+	@Test
+	public void testCompare_different_image() throws Exception {
+		BufferedImage image1 = ImageIO.read(getClass().getResource("hifive_logo.png"));
+		Rectangle rectangle1 = new Rectangle(0, 0, image1.getWidth(), image1.getHeight());
+		BufferedImage image2 = ImageIO.read(getClass().getResource("hifive_logo_part.png"));
+		Rectangle rectangle2 = new Rectangle(0, 0, image2.getWidth(), image2.getHeight());
+		DiffPoints result = new IgnoringClearPixelsImageComparator().compare(image1, rectangle1, image2, rectangle2);
+
+		assertThat(result.isFailed(), is(true));
+	}
+
+	/**
+	 * 1pxだけ違う画像を比較する => 失敗
+	 */
+	@Test
+	public void testCompare_different_1px() throws Exception {
+		BufferedImage image1 = ImageIO.read(getClass().getResource("hifive_logo.png"));
+		BufferedImage image2 = ImageIO.read(getClass().getResource("hifive_logo.png"));
+
+		// 1pxだけ色を変える
+		Random random = new Random();
+		int x = random.nextInt(image2.getWidth());
+		int y = random.nextInt(image2.getHeight());
+		image2.setRGB(x, y, image2.getRGB(x, y) - 1);
+
+		Rectangle rectangle = new Rectangle(0, 0, image1.getWidth(), image2.getHeight());
+
+		DiffPoints result = new IgnoringClearPixelsImageComparator().compare(image1, rectangle, image2, rectangle);
+
+		assertThat(result.isFailed(), is(true));
+		assertThat(result.getDiffPoints().size(), is(1));
+		assertThat(result.getSizeDiffPoints().isEmpty(), is(true));
+		assertThat(result.getDiffPoints().get(0), is(new Point(x, y)));
+	}
+
+	/**
+	 * 1pxだけ違う画像を比較する.透明度が0x00の場合 => 成功
+	 */
+	@Test
+	public void testCompare_different_but_clear_1px() throws Exception {
+		BufferedImage image1 = ImageIO.read(getClass().getResource("hifive_logo.png"));
+		BufferedImage image2 = ImageIO.read(getClass().getResource("hifive_logo.png"));
+
+		// 1pxだけ色を変える
+		Random random = new Random();
+		int x = random.nextInt(image2.getWidth());
+		int y = random.nextInt(image2.getHeight());
+		image2.setRGB(x, y, (image2.getRGB(x, y) - 1) & 0x00FFFFFF);
+
+		Rectangle rectangle = new Rectangle(0, 0, image1.getWidth(), image2.getHeight());
+
+		DiffPoints result = new IgnoringClearPixelsImageComparator().compare(image1, rectangle, image2, rectangle);
+
+		assertThat(result.isSucceeded(), is(true));
+		assertThat(result.isFailed(), is(false));
+	}
+
+	/**
+	 * 1pxだけ違う画像を比較する.透明度が0xFEの場合 => 成功
+	 */
+	@Test
+	public void testCompare_different_but_clear_0xFE_1px() throws Exception {
+		BufferedImage image1 = ImageIO.read(getClass().getResource("hifive_logo.png"));
+		BufferedImage image2 = ImageIO.read(getClass().getResource("hifive_logo.png"));
+
+		// 1pxだけ色を変える
+		Random random = new Random();
+		int x = random.nextInt(image2.getWidth());
+		int y = random.nextInt(image2.getHeight());
+		image2.setRGB(x, y, (image2.getRGB(x, y) - 1) & 0xFEFFFFFF);
+
+		Rectangle rectangle = new Rectangle(0, 0, image1.getWidth(), image2.getHeight());
+
+		DiffPoints result = new IgnoringClearPixelsImageComparator().compare(image1, rectangle, image2, rectangle);
+
+		assertThat(result.isSucceeded(), is(true));
+		assertThat(result.isFailed(), is(false));
+	}
+
+	/**
+	 * 端に差分がある場合 => 失敗
+	 *
+	 * @throws Exception
+	 */
+	@Test
+	public void testCompare_different_area() throws Exception {
+		BufferedImage image = ImageIO.read(getClass().getResource("hifive_logo.png"));
+		Rectangle rectangle1 = new Rectangle(0, 0, image.getWidth(), image.getHeight());
+		Rectangle rectangle2 = new Rectangle(0, 0, image.getWidth() - 1, image.getHeight() - 1);
+		DiffPoints result = new IgnoringClearPixelsImageComparator().compare(image, rectangle1, image, rectangle2);
+
+		assertThat(result.isFailed(), is(true));
+		assertThat(result.getDiffPoints().isEmpty(), is(true));
+		assertThat(result.getSizeDiffPoints().isEmpty(), is(false));
+
+		Comparator<Point> comparator = new Comparator<Point>() {
+			@Override
+			public int compare(Point o1, Point o2) {
+				if (o1.x != o2.x)
+					return Integer.compare(o1.x, o2.x);
+				if (o1.y != o2.y)
+					return Integer.compare(o1.y, o2.y);
+				return 0;
+			}
+		};
+
+		Set<Point> expectedDiffPoints = new TreeSet<Point>(comparator);
+		for (int x = 0; x < image.getWidth(); x++) {
+			expectedDiffPoints.add(new Point(x, image.getHeight()));
+		}
+		for (int y = 0; y < image.getHeight(); y++) {
+			expectedDiffPoints.add(new Point(image.getWidth(), y));
+		}
+
+		Set<Point> diffPoints = new TreeSet<Point>(comparator);
+		diffPoints.addAll(result.getSizeDiffPoints());
+		assertThat(diffPoints, is(expectedDiffPoints));
+	}
+
+}

--- a/pitalium/src/test/java/com/htmlhifive/pitalium/image/util/IgnoringClearPixelsImageComparatorTest.java
+++ b/pitalium/src/test/java/com/htmlhifive/pitalium/image/util/IgnoringClearPixelsImageComparatorTest.java
@@ -193,8 +193,8 @@ public class IgnoringClearPixelsImageComparatorTest {
 		int x = random.nextInt(image2.getWidth());
 		int y = random.nextInt(image2.getHeight());
 		image2.setRGB(x, y, (image2.getRGB(x, y) - 1) & 0xFEFFFFFF); // 透明
-		int x2 = (x + 1) % x;
-		int y2 = (y + 1) % y;
+		int x2 = (x + 1) % image2.getWidth();
+		int y2 = (y + 1) % image2.getHeight();
 		image2.setRGB(x2, y2, (image2.getRGB(x2, y2) - 1) & 0xFEFFFFFF); // 透明
 
 		Rectangle rectangle = new Rectangle(0, 0, image1.getWidth(), image2.getHeight());
@@ -218,8 +218,8 @@ public class IgnoringClearPixelsImageComparatorTest {
 		int x = random.nextInt(image2.getWidth());
 		int y = random.nextInt(image2.getHeight());
 		image2.setRGB(x, y, (image2.getRGB(x, y) - 1)); // 透明でない
-		int x2 = (x + 1) % x;
-		int y2 = (y + 1) % y;
+		int x2 = (x + 1) % image2.getWidth();
+		int y2 = (y + 1) % image2.getHeight();
 		image2.setRGB(x2, y2, (image2.getRGB(x2, y2) - 1) & 0xFEFFFFFF); // 透明
 
 		Rectangle rectangle = new Rectangle(0, 0, image1.getWidth(), image2.getHeight());

--- a/pitalium/src/test/java/com/htmlhifive/pitalium/image/util/ImageComparatorFactoryTest.java
+++ b/pitalium/src/test/java/com/htmlhifive/pitalium/image/util/ImageComparatorFactoryTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2015-2016 NS Solutions Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.htmlhifive.pitalium.image.util;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import com.htmlhifive.pitalium.image.model.CompareOption;
+
+public class ImageComparatorFactoryTest {
+
+	ImageComparatorFactory instance = ImageComparatorFactory.getInstance();
+
+	@Test
+	public void compareOptionがnullの場合はデフォルト() throws Exception {
+		ImageComparator actual = instance.getImageComparator(null);
+		assertTrue(actual instanceof DefaultImageComparator);
+	}
+
+	@Test
+	public void compareOptionの要素数が0の場合はデフォルト() throws Exception {
+		ImageComparator actual = instance.getImageComparator(new CompareOption[0]);
+		assertTrue(actual instanceof DefaultImageComparator);
+	}
+
+	@Test
+	public void compareOptionにIGNORE_CLEAR_PIXELSが含まれていたらIgnoringClearPixelsImageComparator() throws Exception {
+		ImageComparator actual = instance
+				.getImageComparator(new CompareOption[] { CompareOption.STRICT, CompareOption.IGNORE_CLEAR_PIXELS });
+		assertTrue(actual instanceof IgnoringClearPixelsImageComparator);
+	}
+
+	@Test
+	public void compareOptionにIGNORE_CLEAR_PIXELSが含まれていなかったら場合はデフォルト() throws Exception {
+		ImageComparator actual = instance.getImageComparator(new CompareOption[] { CompareOption.STRICT });
+		assertTrue(actual instanceof DefaultImageComparator);
+	}
+
+}


### PR DESCRIPTION
お疲れ様です。pitaliumは素晴らしいライブラリで
今後のさらなる拡張に期待しております！
//hifiveから独立してもいいのではとすら思っています
自分もそれに貢献できればと思いプルリクエストをなげさせていただきました。
本件ご検討いただけないでしょうか。

◆背景
自分もpitaliumの利用を検討しています。
古いシステムのテストの一環としてキャプチャの比較を行いたいと思っているのですが、
画面には時間やシーケンス値など、キャプチャを撮った日時に依存してしまう
部分があり、必ず比較が失敗してしまいます。
pitaliumには、その部分をidやclassで指定できる機能がありますが、
画面に必ずしもidやclassが付いているとは限りません。
つけようにも、本番化済みの業務システムに対して、
「テストが楽になるようにIDをつけるだけのリリース」も許されなく…

◆目的
そこで、cssセレクタを用いた比較除外方法の他に、
模範解答画像に仕掛けを施して除外設定できるようにすることで、
本番化済みのシステムの改造なしで
pitaliumが利用できるようにしたいと思っています。

◆方法
模範解答画像の画素の透明度が0xFFで<b>ない</b>ときに、
画像の比較を除外するようにして見ました。
- キャプチャした画像の透明度が0xFFになることはない
-  完全に透明にするのではなく、薄透明にすることでなにを除外したかがわかるような模範解答画像もあり

お手数お掛け致しますが、よろしくお願いいたします。



