### PR TITLE
fix issue #98

### DIFF
--- a/pitalium/src/main/java/com/htmlhifive/pitalium/core/selenium/PtlWebDriver.java
+++ b/pitalium/src/main/java/com/htmlhifive/pitalium/core/selenium/PtlWebDriver.java
@@ -807,7 +807,9 @@ public abstract class PtlWebDriver extends RemoteWebDriver {
 			Pair<CompareTarget, ScreenshotParams> pair = targetParams.get(i);
 			// Exclude領域の座標を更新
 			for (ScreenAreaWrapper wrapper : pair.getRight().getExcludes()) {
-				wrapper.setArea(wrapper.getArea().move(0, partialScrollTops[i] * scale));
+				if (wrapper.getSelector() != null) {
+					wrapper.setArea(wrapper.getArea().move(0, partialScrollTops[i] * scale));
+				}
 			}
 			// 画像の結合
 			List<BufferedImage> targetScreenshots = allTargetScreenshots.get(i);
@@ -907,7 +909,9 @@ public abstract class PtlWebDriver extends RemoteWebDriver {
 
 		// Exclude領域の座標を更新
 		for (ScreenAreaWrapper wrapper : params.getExcludes()) {
-			wrapper.setArea(wrapper.getArea().move(0, scrollTop * scale));
+			if (wrapper.getSelector() != null) {
+				wrapper.setArea(wrapper.getArea().move(0, scrollTop * scale));
+			}
 		}
 
 		LOG.debug("[TakeMoveScreenshot (image processing start)]");
@@ -1403,7 +1407,9 @@ public abstract class PtlWebDriver extends RemoteWebDriver {
 
 		LOG.trace("[CropScreenshot] Move excludes. (deltaX: {}, deltaY: {})", deltaX, deltaY);
 		for (ScreenAreaWrapper wrapper : params.getExcludes()) {
-			wrapper.setArea(wrapper.getArea().move(deltaX, deltaY));
+			if (wrapper.getSelector() != null) {
+				wrapper.setArea(wrapper.getArea().move(deltaX, deltaY));
+			}
 		}
 
 		return targetImage;
@@ -1553,7 +1559,7 @@ public abstract class PtlWebDriver extends RemoteWebDriver {
 		params.getTarget().updatePosition(currentScale, moveX, moveY);
 
 		for (ScreenAreaWrapper wrapper : params.getExcludes()) {
-			wrapper.updatePosition(currentScale, moveX, moveY);
+			wrapper.updatePosition(currentScale);
 		}
 	}
 

--- a/pitalium/src/test/java/com/htmlhifive/pitalium/it/screenshot/excludeInScroll/ExcludeAreaInScrollTest.java
+++ b/pitalium/src/test/java/com/htmlhifive/pitalium/it/screenshot/excludeInScroll/ExcludeAreaInScrollTest.java
@@ -16,9 +16,10 @@
 
 package com.htmlhifive.pitalium.it.screenshot.excludeInScroll;
 
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
-import static org.junit.Assume.*;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assume.assumeFalse;
 
 import org.junit.Test;
 import org.openqa.selenium.WebElement;
@@ -48,21 +49,22 @@ public class ExcludeAreaInScrollTest extends PtlItScreenshotTestBase {
 		// 一つ目のTRを除外する
 		WebElement row = driver.executeJavaScript("" + "var table = document.getElementById('table-scroll');"
 				+ "return table.getElementsByTagName('tr')[0];");
+		Rect tableRect = getRectById("table-scroll");
 		Rect rowRect = getPixelRect(row);
+
+		double x = Math.round(rowRect.x - tableRect.x);
+		double y = Math.round(rowRect.y - tableRect.y);
+		double width = Math.round(rowRect.width);
+		double height = Math.round(rowRect.height);
+
 		ScreenshotArgument arg = ScreenshotArgument.builder("s").addNewTargetByCssSelector("#table-scroll > tbody")
-				.scrollTarget(true).moveTarget(true).addExclude(rowRect.x, rowRect.y, rowRect.width, rowRect.height)
-				.build();
+				.scrollTarget(true).moveTarget(true).addExclude(x, y, width, height).build();
 		assertionView.assertView(arg);
 
 		// Check
 		TargetResult result = loadTargetResults("s").get(0);
 		assertThat(result.getExcludes(), hasSize(1));
 
-		Rect tableRect = getRectById("table-scroll");
-		double x = Math.round(rowRect.x - tableRect.x);
-		double y = Math.round(rowRect.y - tableRect.y);
-		double width = Math.round(rowRect.width);
-		double height = Math.round(rowRect.height);
 		assertThat(result.getExcludes().get(0).getRectangle(), is(new RectangleArea(x, y, width, height)));
 	}
 
@@ -82,20 +84,20 @@ public class ExcludeAreaInScrollTest extends PtlItScreenshotTestBase {
 		WebElement row = driver.executeJavaScript("" + "var table = document.getElementById('table-scroll');"
 				+ "var tr = table.getElementsByTagName('tr');" + "return tr[tr.length - 1];");
 		Rect rowRect = getPixelRect(row);
+		Rect tableRect = getPixelRectById("table-scroll");
+		double x = Math.round(rowRect.x - tableRect.x);
+		double y = Math.round(rowRect.y - tableRect.y);
+		double width = Math.round(rowRect.width);
+		double height = Math.round(rowRect.height);
+
 		ScreenshotArgument arg = ScreenshotArgument.builder("s").addNewTargetByCssSelector("#table-scroll > tbody")
-				.scrollTarget(true).moveTarget(true).addExclude(rowRect.x, rowRect.y, rowRect.width, rowRect.height)
-				.build();
+				.scrollTarget(true).moveTarget(true).addExclude(x, y, width, height).build();
 		assertionView.assertView(arg);
 
 		// Check
 		TargetResult result = loadTargetResults("s").get(0);
 		assertThat(result.getExcludes(), hasSize(1));
 
-		Rect tableRect = getPixelRectById("table-scroll");
-		double x = Math.round(rowRect.x - tableRect.x);
-		double y = Math.round(rowRect.y - tableRect.y);
-		double width = Math.round(rowRect.width);
-		double height = Math.round(rowRect.height);
 		assertThat(result.getExcludes().get(0).getRectangle(), is(new RectangleArea(x, y, width, height)));
 	}
 
@@ -114,21 +116,21 @@ public class ExcludeAreaInScrollTest extends PtlItScreenshotTestBase {
 		// 一つ目のTRを除外する
 		WebElement row = driver.executeJavaScript("" + "var table = document.getElementById('table-scroll');"
 				+ "return table.getElementsByTagName('tr')[0];");
+		Rect tableRect = getPixelRectById("table-scroll");
 		Rect rowRect = getPixelRect(row);
+
+		double x = Math.round(rowRect.x - tableRect.x);
+		double y = Math.round(rowRect.y - tableRect.y);
+		double width = Math.round(rowRect.width);
+		double height = Math.round(rowRect.height);
+
 		ScreenshotArgument arg = ScreenshotArgument.builder("s").addNewTargetByCssSelector("#table-scroll > tbody")
-				.scrollTarget(true).moveTarget(false).addExclude(rowRect.x, rowRect.y, rowRect.width, rowRect.height)
-				.build();
+				.scrollTarget(true).moveTarget(false).addExclude(x, y, width, height).build();
 		assertionView.assertView(arg);
 
 		// Check
 		TargetResult result = loadTargetResults("s").get(0);
 		assertThat(result.getExcludes(), hasSize(1));
-
-		Rect tableRect = getPixelRectById("table-scroll");
-		double x = Math.round(rowRect.x - tableRect.x);
-		double y = Math.round(rowRect.y - tableRect.y);
-		double width = Math.round(rowRect.width);
-		double height = Math.round(rowRect.height);
 		assertThat(result.getExcludes().get(0).getRectangle(), is(new RectangleArea(x, y, width, height)));
 	}
 
@@ -147,21 +149,21 @@ public class ExcludeAreaInScrollTest extends PtlItScreenshotTestBase {
 		// 最後のTRを除外する
 		WebElement row = driver.executeJavaScript("" + "var table = document.getElementById('table-scroll');"
 				+ "var tr = table.getElementsByTagName('tr');" + "return tr[tr.length - 1];");
+		Rect tableRect = getPixelRectById("table-scroll");
 		Rect rowRect = getPixelRect(row);
+
+		double x = Math.round(rowRect.x - tableRect.x);
+		double y = Math.round(rowRect.y - tableRect.y);
+		double width = Math.round(rowRect.width);
+		double height = Math.round(rowRect.height);
+
 		ScreenshotArgument arg = ScreenshotArgument.builder("s").addNewTargetByCssSelector("#table-scroll > tbody")
-				.scrollTarget(true).moveTarget(false).addExclude(rowRect.x, rowRect.y, rowRect.width, rowRect.height)
-				.build();
+				.scrollTarget(true).moveTarget(false).addExclude(x, y, width, height).build();
 		assertionView.assertView(arg);
 
 		// Check
 		TargetResult result = loadTargetResults("s").get(0);
 		assertThat(result.getExcludes(), hasSize(1));
-
-		Rect tableRect = getPixelRectById("table-scroll");
-		double x = Math.round(rowRect.x - tableRect.x);
-		double y = Math.round(rowRect.y - tableRect.y);
-		double width = Math.round(rowRect.width);
-		double height = Math.round(rowRect.height);
 		assertThat(result.getExcludes().get(0).getRectangle(), is(new RectangleArea(x, y, width, height)));
 	}
 


### PR DESCRIPTION
Exclude領域の座標がtargetの座標により変更されるため、引渡パラメータのExclude領域の座標がresult.jsonファイルのExclude領域の座標と違っている。
⇒targetの座標をベースポイントにし、targetの座標によりExclude領域の座標を変更する処理を全て無視する。
※moveTarget = falseの場合、targetによりExclude領域の座標を更新する。