### PR TITLE
#134 type:SIMILARITYでしきい値1.0にしても差分が無視されてしまうのを修正

### DIFF
--- a/pitalium/src/main/java/com/htmlhifive/pitalium/image/util/SimilarityImageComparator.java
+++ b/pitalium/src/main/java/com/htmlhifive/pitalium/image/util/SimilarityImageComparator.java
@@ -19,6 +19,10 @@ import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.image.BufferedImage;
 import java.util.List;
+import java.util.regex.Pattern;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.htmlhifive.pitalium.image.model.ComparedRectangleArea;
 import com.htmlhifive.pitalium.image.model.ImageComparedResult;
@@ -32,6 +36,8 @@ import com.htmlhifive.pitalium.image.model.SimilarityUnit;
  */
 class SimilarityImageComparator extends ImageComparator<SimilarityComparisonParameters> {
 
+	private static final Logger LOG = LoggerFactory.getLogger(DefaultImageComparator.class);
+
 	/**
 	 * デフォルトコンストラクタ
 	 */
@@ -44,7 +50,13 @@ class SimilarityImageComparator extends ImageComparator<SimilarityComparisonPara
 	 * @param parameters 比較用パラメータ
 	 */
 	SimilarityImageComparator(SimilarityComparisonParameters parameters) {
-		this.parameters = parameters;
+		double pixleByPixelThreshold = truncateDecimalPoint(parameters.getPixleByPixelThreshold());
+		double featherMatrixThreshold = truncateDecimalPoint(parameters.getFeatherMatrixThreshold());
+		double thresDiffThreshold = truncateDecimalPoint(parameters.getThresDiffThreshold());
+		double totalDiffThreshold = truncateDecimalPoint(parameters.getTotalDiffThreshold());
+
+		this.parameters = new SimilarityComparisonParameters(pixleByPixelThreshold, featherMatrixThreshold,
+				thresDiffThreshold, totalDiffThreshold);
 	}
 
 	@Override
@@ -70,5 +82,38 @@ class SimilarityImageComparator extends ImageComparator<SimilarityComparisonPara
 			isSucceed = false;
 		}
 		return new SimilarityImageComparedResult(isSucceed, unit);
+	}
+
+	/**
+	 * 実数の小数点以下の桁数を2桁にする。3桁目以降は切り捨てる。
+	 *
+	 * @param number 実数
+	 * @return 小数点3桁目以降を切り捨てた値
+	 */
+	private double truncateDecimalPoint(double number) {
+		int scale = getDecimalPointLength(number);
+		double result = number;
+		if (scale > 2) {
+			result = Math.floor(number * 100) / 100;
+			LOG.warn("Truncating similarlity threshold to {}. Please set the threshold with two decimal places.",
+					result);
+		}
+		return result;
+	}
+
+	/**
+	 * 実数の小数点以下の桁数を取得する。
+	 *
+	 * @param number 実数
+	 * @return 小数点以下の桁数
+	 */
+	private int getDecimalPointLength(double number) {
+		String[] numbers = String.valueOf(number).split(Pattern.quote("."));
+		int result = 0;
+
+		if (numbers.length == 2) {
+			result = numbers[1].length();
+		}
+		return result;
 	}
 }

--- a/pitalium/src/main/java/com/htmlhifive/pitalium/image/util/SimilarityUtils.java
+++ b/pitalium/src/main/java/com/htmlhifive/pitalium/image/util/SimilarityUtils.java
@@ -227,8 +227,8 @@ public class SimilarityUtils {
 		}
 		double similarity = 1 - min;
 
-		// round similarity to 2 decimal places.
-		similarity = (double) Math.round(similarity * 100) / 100;
+		// floor similarity to 2 decimal places.
+		similarity = Math.floor(similarity * 100) / 100;
 
 		return similarity;
 	}
@@ -298,8 +298,8 @@ public class SimilarityUtils {
 
 		double similarity = 1 - calcFeatureDistance(expectedFeature, actualFeature);
 
-		// round similarity to 2 decimal places.
-		similarity = (double) Math.round(similarity * 100) / 100;
+		// floor similarity to 2 decimal places.
+		similarity = Math.floor(similarity * 100) / 100;
 
 		return similarity;
 	}
@@ -384,10 +384,10 @@ public class SimilarityUtils {
 		similarityThresDiff = 1 - (double) thresDiffMin / (prep.actualWidth * prep.actualHeight);
 		similarityTotalDiff = 1 - (double) totalDiffMin / (prep.actualWidth * prep.actualHeight);
 
-		// round similarities to 2 decimal place.
-		similarity = (double) Math.round(similarity * 100) / 100;
-		similarityThresDiff = (double) Math.round(similarityThresDiff * 100) / 100;
-		similarityTotalDiff = (double) Math.round(similarityTotalDiff * 100) / 100;
+		// floor similarities to 2 decimal place.
+		similarity = Math.floor(similarity * 100) / 100;
+		similarityThresDiff = Math.floor(similarityThresDiff * 100) / 100;
+		similarityTotalDiff = Math.floor(similarityTotalDiff * 100) / 100;
 
 		if (offset == null) {
 			offset = new Offset(0, 0);


### PR DESCRIPTION
小数点第3位で四捨五入していたところを切り捨てるように変更。

・ユーザが指定する閾値について
閾値は指定したそのままの値、計算結果の類似度は小数点第3位を切り捨てて比較を行う。
なので、閾値に小数点3桁以降を書いても意味なしであることを明示的に示しておく必要がある。