### PR TITLE
性能測定機能を追加

### DIFF
--- a/pitalium/.classpath
+++ b/pitalium/.classpath
@@ -47,5 +47,31 @@
 	<classpathentry kind="lib" path="libs/selenium-support-3.8.1.jar"/>
 	<classpathentry kind="lib" path="libs/gson-2.8.2.jar"/>
 	<classpathentry kind="lib" path="libs/guava-23.0.jar"/>
+	<classpathentry kind="lib" path="libs/animal-sniffer-annotations-1.14.jar"/>
+	<classpathentry kind="lib" path="libs/ant-1.8.3.jar"/>
+	<classpathentry kind="lib" path="libs/ant-junit-1.8.3.jar"/>
+	<classpathentry kind="lib" path="libs/ant-launcher-1.8.3.jar"/>
+	<classpathentry kind="lib" path="libs/asm-5.0.1.jar"/>
+	<classpathentry kind="lib" path="libs/asm-analysis-5.0.1.jar"/>
+	<classpathentry kind="lib" path="libs/asm-commons-5.0.1.jar"/>
+	<classpathentry kind="lib" path="libs/asm-tree-5.0.1.jar"/>
+	<classpathentry kind="lib" path="libs/asm-util-5.0.1.jar"/>
+	<classpathentry kind="lib" path="libs/byte-buddy-1.7.5.jar"/>
+	<classpathentry kind="lib" path="libs/cobertura-2.1.1.jar"/>
+	<classpathentry kind="lib" path="libs/error_prone_annotations-2.0.18.jar"/>
+	<classpathentry kind="lib" path="libs/j2objc-annotations-1.1.jar"/>
+	<classpathentry kind="lib" path="libs/javassist-3.16.1-GA.jar"/>
+	<classpathentry kind="lib" path="libs/jaxen-1.1.4.jar"/>
+	<classpathentry kind="lib" path="libs/jetty-6.1.14.jar"/>
+	<classpathentry kind="lib" path="libs/jsr305-1.3.9.jar"/>
+	<classpathentry kind="lib" path="libs/logback-classic-1.0.13.jar"/>
+	<classpathentry kind="lib" path="libs/logback-core-1.0.13.jar"/>
+	<classpathentry kind="lib" path="libs/ognl-3.0.6.jar"/>
+	<classpathentry kind="lib" path="libs/oro-2.0.8.jar"/>
+	<classpathentry kind="lib" path="libs/powermock-api-mockito-common-1.6.6.jar"/>
+	<classpathentry kind="lib" path="libs/servlet-api-2.5-6.1.14.jar"/>
+	<classpathentry kind="lib" path="libs/thymeleaf-2.1.3.RELEASE.jar"/>
+	<classpathentry kind="lib" path="libs/thymeleaf-spring4-2.1.3.RELEASE.jar"/>
+	<classpathentry kind="lib" path="libs/unbescape-1.0.jar"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/pitalium/ivy.xml
+++ b/pitalium/ivy.xml
@@ -22,6 +22,7 @@
 		<dependency org="org.powermock" name="powermock-module-junit4" rev="1.6.6" conf="test->default" />
         <dependency org="org.hamcrest" name="java-hamcrest" rev="2.0.0.0" conf="test->default" />
         <dependency org="commons-io" name="commons-io" rev="2.5" conf="default" />
+		<dependency org="org.thymeleaf" name="thymeleaf-spring4" rev="2.1.3.RELEASE" conf="default"/>
 		<!-- ソースが必要な場合は下記のコメントを外してください。 -->
 		<dependency org="org.apache.commons" name="commons-lang3" rev="3.5" conf="sources" />
 		<dependency org="org.slf4j" name="slf4j-api" rev="1.7.25" conf="sources" />

--- a/pitalium/src/main/java/com/htmlhifive/pitalium/core/TelemetricTestBase.java
+++ b/pitalium/src/main/java/com/htmlhifive/pitalium/core/TelemetricTestBase.java
@@ -1,0 +1,35 @@
+package com.htmlhifive.pitalium.core;
+
+import org.junit.Before;
+import org.junit.Rule;
+
+import com.htmlhifive.pitalium.core.rules.PerformanceTelemetry;
+import com.htmlhifive.pitalium.core.selenium.TelemetricWebDriver;
+
+/**
+ * 性能測定モードでのテスト実行用の基底クラス。テスト実行に必要な&#064;Rule、&#064;ClassRuleが定義されています。<br/>
+ * 本テストツールの機能を性能測定モードで利用する場合は、このクラスを拡張してテストクラスを実装してください。
+ */
+public class TelemetricTestBase extends PtlTestBase {
+
+	/**
+	 * 性能測定結果の記録を行うクラス。
+	 */
+	@Rule
+	public PerformanceTelemetry measure = new PerformanceTelemetry();
+
+	/**
+	 * テスト実行時のセットアップを行います。
+	 */
+	@Override
+	@Before
+	public void setUp() {
+		super.setUp();
+		LOG.debug("[TelemetricTestBase>setUp start]");
+		TelemetricWebDriver telemetricWebDriver = (TelemetricWebDriver) driver;
+		telemetricWebDriver.setPerformanceMeasure(measure);
+		measure.setTelemetricWebDriver(telemetricWebDriver);
+		measure.setCapabilities(capabilities);
+		LOG.debug("[TelemetricTestBase>setUp finished]");
+	}
+}

--- a/pitalium/src/main/java/com/htmlhifive/pitalium/core/config/EnvironmentConfig.java
+++ b/pitalium/src/main/java/com/htmlhifive/pitalium/core/config/EnvironmentConfig.java
@@ -97,6 +97,11 @@ public class EnvironmentConfig implements Serializable {
 	private boolean debug = false;
 
 	/**
+	 * 性能測定モード
+	 */
+	private PerformanceMeasurementMode performanceMeasurementMode = PerformanceMeasurementMode.OFF;
+
+	/**
 	 * デフォルトの設定値を持つオブジェクトを生成します。
 	 */
 	public EnvironmentConfig() {
@@ -197,6 +202,15 @@ public class EnvironmentConfig implements Serializable {
 	 */
 	public WebDriverSessionLevel getWebDriverSessionLevel() {
 		return webDriverSessionLevel;
+	}
+
+	/**
+	 * 性能測定モードを取得します。
+	 *
+	 * @return 性能測定モード
+	 */
+	public PerformanceMeasurementMode getPerformanceMeasurementMode() {
+		return performanceMeasurementMode;
 	}
 
 	/**
@@ -308,6 +322,15 @@ public class EnvironmentConfig implements Serializable {
 	}
 
 	/**
+	 * 性能測定モードを設定します。
+	 *
+	 * @param performanceMeasurementMode 性能測定モード
+	 */
+	public void setPerformanceMeasurementMode(PerformanceMeasurementMode performanceMeasurementMode) {
+		this.performanceMeasurementMode = performanceMeasurementMode;
+	}
+
+	/**
 	 * デバッグモード実行フラグを設定します。
 	 * 
 	 * @param debug デバッグモード実行フラグ
@@ -355,6 +378,7 @@ public class EnvironmentConfig implements Serializable {
 			ev.setCapabilitiesFilePath(config.capabilitiesFilePath);
 			ev.setPersister(config.persister);
 			ev.setWebDriverSessionLevel(config.webDriverSessionLevel);
+			ev.setPerformanceMeasurementMode(config.performanceMeasurementMode);
 			ev.setDebug(config.debug);
 			return ev;
 		}
@@ -477,6 +501,17 @@ public class EnvironmentConfig implements Serializable {
 		 */
 		public Builder autoResizeWindow(boolean b) {
 			config.autoResizeWindow = b;
+			return this;
+		}
+
+		/**
+		 * 性能測定モードを設定します。
+		 *
+		 * @param mode 性能測定モード
+		 * @return このビルダーオブジェクト自身
+		 */
+		public Builder performanceMeasurementMode(PerformanceMeasurementMode mode) {
+			config.performanceMeasurementMode = mode;
 			return this;
 		}
 

--- a/pitalium/src/main/java/com/htmlhifive/pitalium/core/config/PerformanceMeasurementMode.java
+++ b/pitalium/src/main/java/com/htmlhifive/pitalium/core/config/PerformanceMeasurementMode.java
@@ -1,0 +1,17 @@
+package com.htmlhifive.pitalium.core.config;
+
+/**
+ * 性能測定モードを表す定数クラス
+ */
+public enum PerformanceMeasurementMode {
+
+	/**
+	 * 性能を測定しません。
+	 */
+	OFF,
+	/**
+	 * 性能を測定します。
+	 */
+	ON
+
+}

--- a/pitalium/src/main/java/com/htmlhifive/pitalium/core/model/Performance.java
+++ b/pitalium/src/main/java/com/htmlhifive/pitalium/core/model/Performance.java
@@ -1,0 +1,210 @@
+package com.htmlhifive.pitalium.core.model;
+
+import java.io.IOException;
+import java.util.List;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * 性能測定結果を保持するクラス。
+ */
+public class Performance {
+	private String url;
+	private List<PerformanceResourceTiming> resourceTimings;
+	private PerformanceTiming navigationTiming;
+	private List<PerformanceMark> marks;
+	private List<PerformanceMeasure> measures;
+	private String browser;
+	private String id;
+	private String label;
+
+	/**
+	 * 空のオブジェクトを生成します。
+	 */
+	public Performance() {
+	}
+
+	/**
+	 * 性能測定時のURLを取得します。
+	 * 
+	 * @return 性能測定時のURL
+	 */
+	public String getUrl() {
+		return url;
+	}
+
+	/**
+	 * 性能測定時のURLを設定します。
+	 * 
+	 * @param url 性能測定時のURL
+	 */
+	public void setUrl(String url) {
+		this.url = url;
+	}
+
+	/**
+	 * Resource Timingのリストを取得します。
+	 * 
+	 * @return Resource Timingのリスト
+	 */
+	public List<PerformanceResourceTiming> getResourceTimings() {
+		return resourceTimings;
+	}
+
+	/**
+	 * Resource Timingのリストを設定します。
+	 * 
+	 * @param resourceTimings Resource Timingのリスト
+	 */
+	public void setResourceTimings(List<PerformanceResourceTiming> resourceTimings) {
+		this.resourceTimings = resourceTimings;
+	}
+
+	/**
+	 * Navigation Timingを取得します。
+	 * 
+	 * @return Navigation Timing
+	 */
+	public PerformanceTiming getNavigationTiming() {
+		return navigationTiming;
+	}
+
+	/**
+	 * Navigation Timingを設定します。
+	 * 
+	 * @param navigationTiming Navigation Timing
+	 */
+	public void setNavigationTiming(PerformanceTiming navigationTiming) {
+		this.navigationTiming = navigationTiming;
+	}
+
+	/**
+	 * 性能測定に使用したブラウザを取得します。
+	 * 
+	 * @return 性能測定に使用したブラウザ
+	 */
+	public String getBrowser() {
+		return browser;
+	}
+
+	/**
+	 * 性能測定に使用したブラウザを設定します。
+	 * 
+	 * @param browser 性能測定に使用したブラウザ
+	 */
+	public void setBrowser(String browser) {
+		this.browser = browser;
+	}
+
+	/**
+	 * 性能測定結果のIDを取得します。
+	 * 
+	 * @return ID 性能測定結果のID
+	 */
+	public String getId() {
+		return id;
+	}
+
+	/**
+	 * 性能測定結果のIDを設定します。
+	 * 
+	 * @param id 性能測定結果のID
+	 */
+	public void setId(String id) {
+		this.id = id;
+	}
+
+	/**
+	 * User Timingのmarkのリストを取得します。
+	 * 
+	 * @return User Timingのmarkのリスト
+	 */
+	public List<PerformanceMark> getMarks() {
+		return marks;
+	}
+
+	/**
+	 * User Timingのmarkのリストを設定します。
+	 * 
+	 * @param marks User Timingのmarkのリスト
+	 */
+	public void setMarks(List<PerformanceMark> marks) {
+		this.marks = marks;
+	}
+
+	/**
+	 * User Timingのmeasureのリストを取得します。
+	 * 
+	 * @return User Timingのmeasureのリスト
+	 */
+	public List<PerformanceMeasure> getMeasures() {
+		return measures;
+	}
+
+	/**
+	 * User Timingのmeasureのリストを設定します。
+	 * 
+	 * @param measures User Timingのmeasureのリスト
+	 */
+	public void setMeasures(List<PerformanceMeasure> measures) {
+		this.measures = measures;
+	}
+
+	/**
+	 * 性能測定結果を更新します。
+	 * 
+	 * @param performance 性能測定結果の更新内容
+	 */
+	public void updateWith(Performance performance) {
+		setUrl(performance.getUrl());
+		setResourceTimings(performance.getResourceTimings());
+		setNavigationTiming(performance.getNavigationTiming());
+		setMarks(performance.getMarks());
+		setMeasures(performance.getMeasures());
+		setBrowser(performance.getBrowser());
+		setId(performance.getId());
+		if (performance.getLabel() != null) {
+			setLabel(performance.getLabel());
+		}
+	}
+
+	/**
+	 * 性能測定結果のラベルを取得します。
+	 * 
+	 * @return 性能測定結果のラベル
+	 */
+	public String getLabel() {
+		return label;
+	}
+
+	/**
+	 * 性能測定結果のラベルを設定します。
+	 * 
+	 * @param label 性能測定結果のラベル
+	 */
+	public void setLabel(String label) {
+		this.label = label;
+	}
+
+	/**
+	 * 性能測定結果のJSON文字列表現をパースします。
+	 * 
+	 * @param obj 性能測定結果のJSON文字列表現
+	 * @return 性能測定結果
+	 */
+	public static Performance parseJson(Object obj) {
+		if (!(obj instanceof String)) {
+			throw new IllegalArgumentException("Returned object cannot be parsed to String.");
+		}
+		String json = (String) obj;
+		ObjectMapper objectMapper = new ObjectMapper();
+		objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+		try {
+			Performance performanceResult = objectMapper.readValue(json, Performance.class);
+			return performanceResult;
+		} catch (IOException e) {
+			throw new IllegalArgumentException(e);
+		}
+	}
+}

--- a/pitalium/src/main/java/com/htmlhifive/pitalium/core/model/PerformanceMark.java
+++ b/pitalium/src/main/java/com/htmlhifive/pitalium/core/model/PerformanceMark.java
@@ -1,0 +1,51 @@
+package com.htmlhifive.pitalium.core.model;
+
+/**
+ * User Timingのmarkを保持するクラス。
+ */
+public class PerformanceMark {
+	private String name;
+	private double startTime;
+
+	/**
+	 * 空のオブジェクトを生成します。
+	 */
+	public PerformanceMark() {
+	}
+
+	/**
+	 * 名前を取得します。
+	 * 
+	 * @return 名前
+	 */
+	public String getName() {
+		return name;
+	}
+
+	/**
+	 * 名前を設定します。
+	 * 
+	 * @param name 名前
+	 */
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	/**
+	 * performance.mark()の呼び出された時間を取得します。
+	 * 
+	 * @return performance.mark()の呼び出された時間
+	 */
+	public double getStartTime() {
+		return startTime;
+	}
+
+	/**
+	 * performance.mark()の呼び出された時間を設定します。
+	 * 
+	 * @param startTime performance.mark()の呼び出された時間
+	 */
+	public void setStartTime(double startTime) {
+		this.startTime = startTime;
+	}
+}

--- a/pitalium/src/main/java/com/htmlhifive/pitalium/core/model/PerformanceMeasure.java
+++ b/pitalium/src/main/java/com/htmlhifive/pitalium/core/model/PerformanceMeasure.java
@@ -1,0 +1,70 @@
+package com.htmlhifive.pitalium.core.model;
+
+/**
+ * User Timingのmeasureを保持するクラス。
+ */
+public class PerformanceMeasure {
+	private String name;
+	private double startTime;
+	private double duration;
+
+	/**
+	 * 空のオブジェクトを生成します。
+	 */
+	public PerformanceMeasure() {
+	}
+
+	/**
+	 * 名前を取得します。
+	 * 
+	 * @return 名前
+	 */
+	public String getName() {
+		return name;
+	}
+
+	/**
+	 * 名前を設定します。
+	 * 
+	 * @param name 名前
+	 */
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	/**
+	 * measureの開始点となるperformance.mark()の呼び出された時間を取得します。
+	 * 
+	 * @return measureの開始点となるperformance.mark()の呼び出された時間
+	 */
+	public double getStartTime() {
+		return startTime;
+	}
+
+	/**
+	 * measureの開始点となるperformance.mark()の呼び出された時間を設定します。
+	 * 
+	 * @param startTime measureの開始点となるperformance.mark()の呼び出された設定
+	 */
+	public void setStartTime(double startTime) {
+		this.startTime = startTime;
+	}
+
+	/**
+	 * performance.measure()で測定した時間を取得します。
+	 * 
+	 * @return performance.measure()で測定した時間
+	 */
+	public double getDuration() {
+		return duration;
+	}
+
+	/**
+	 * performance.measure()で測定した時間を設定します。
+	 * 
+	 * @param duration performance.measure()で測定した時間
+	 */
+	public void setDuration(double duration) {
+		this.duration = duration;
+	}
+}

--- a/pitalium/src/main/java/com/htmlhifive/pitalium/core/model/PerformanceResourceTiming.java
+++ b/pitalium/src/main/java/com/htmlhifive/pitalium/core/model/PerformanceResourceTiming.java
@@ -1,0 +1,358 @@
+package com.htmlhifive.pitalium.core.model;
+
+/**
+ * Resource Timingを保持するクラス。
+ */
+public class PerformanceResourceTiming {
+	private String name;
+	private double connectStart;
+	private double connectEnd;
+	private long decodedBodySize;
+	private double domainLookupEnd;
+	private double domainLookupStart;
+	private long encodedBodySize;
+	private double fetchStart;
+	private String initiatorType;
+	private String nextHopProtocol;
+	private double redirectEnd;
+	private double redirectStart;
+	private double requestStart;
+	private double responseEnd;
+	private double responseStart;
+	private double secureConnectionStart;
+	private long transferSize;
+	private double workerStart;
+
+	/**
+	 * 空のオブジェクトを生成します。
+	 */
+	public PerformanceResourceTiming() {
+	}
+
+	/**
+	 * ブラウザからサーバへの接続開始時間を取得します。
+	 * 
+	 * @return ブラウザからサーバへの接続開始時間
+	 */
+	public double getConnectStart() {
+		return connectStart;
+	}
+
+	/**
+	 * ブラウザからサーバへの接続開始時間を設定します。
+	 * 
+	 * @param connectStart ブラウザからサーバへの接続開始時間
+	 */
+	public void setConnectStart(double connectStart) {
+		this.connectStart = connectStart;
+	}
+
+	/**
+	 * リソースのURLを取得します。
+	 * 
+	 * @return リソースのURL
+	 */
+	public String getName() {
+		return name;
+	}
+
+	/**
+	 * リソースのURLを設定します。
+	 * 
+	 * @param name リソースのURL
+	 */
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	/**
+	 * ブラウザからサーバへの接続確立完了時間を取得します。
+	 * 
+	 * @return ブラウザからサーバへの接続確立完了時間
+	 */
+	public double getConnectEnd() {
+		return connectEnd;
+	}
+
+	/**
+	 * ブラウザからサーバへの接続確立完了時間を設定します。
+	 * 
+	 * @param connectEnd ブラウザからサーバへの接続確立完了時間
+	 */
+	public void setConnectEnd(double connectEnd) {
+		this.connectEnd = connectEnd;
+	}
+
+	/**
+	 * レスポンスボディのバイト数を取得します。
+	 * 
+	 * @return レスポンスボディのバイト数
+	 */
+	public long getDecodedBodySize() {
+		return decodedBodySize;
+	}
+
+	/**
+	 * レスポンスボディのバイト数を設定します。
+	 * 
+	 * @param decodedBodySize レスポンスボディのバイト数
+	 */
+	public void setDecodedBodySize(long decodedBodySize) {
+		this.decodedBodySize = decodedBodySize;
+	}
+
+	/**
+	 * ブラウザによるリソースの名前解決完了時間を取得します。
+	 * 
+	 * @return ブラウザによるリソースの名前解決完了時間
+	 */
+	public double getDomainLookupEnd() {
+		return domainLookupEnd;
+	}
+
+	/**
+	 * ブラウザによるリソースの名前解決完了時間を設定します。
+	 * 
+	 * @param domainLookupEnd ブラウザによるリソースの名前解決完了時間
+	 */
+	public void setDomainLookupEnd(double domainLookupEnd) {
+		this.domainLookupEnd = domainLookupEnd;
+	}
+
+	/**
+	 * ブラウザによるリソースの名前解決開始時間を取得します。
+	 * 
+	 * @return ブラウザによるリソースの名前解決開始時間
+	 */
+	public double getDomainLookupStart() {
+		return domainLookupStart;
+	}
+
+	/**
+	 * ブラウザによるリソースの名前解決開始時間を設定します。
+	 * 
+	 * @param domainLookupStart ブラウザによるリソースの名前解決開始時間
+	 */
+	public void setDomainLookupStart(double domainLookupStart) {
+		this.domainLookupStart = domainLookupStart;
+	}
+
+	/**
+	 * レスポンスのペイロードのバイト数を取得します。
+	 * 
+	 * @return レスポンスのペイロードのバイト数
+	 */
+	public long getEncodedBodySize() {
+		return encodedBodySize;
+	}
+
+	/**
+	 * レスポンスのペイロードのバイト数を設定します。
+	 * 
+	 * @param encodedBodySize レスポンスのペイロードのバイト数
+	 */
+	public void setEncodedBodySize(long encodedBodySize) {
+		this.encodedBodySize = encodedBodySize;
+	}
+
+	/**
+	 * ブラウザによるリソース取得開始時間を取得します。
+	 * 
+	 * @return ブラウザによるリソース取得開始時間
+	 */
+	public double getFetchStart() {
+		return fetchStart;
+	}
+
+	/**
+	 * ブラウザによるリソース取得開始時間を設定します。
+	 * 
+	 * @param fetchStart ブラウザによるリソース取得開始時間
+	 */
+	public void setFetchStart(double fetchStart) {
+		this.fetchStart = fetchStart;
+	}
+
+	/**
+	 * リソース取得の契機の種別を取得します。
+	 * 
+	 * @return リソース取得の契機の種別
+	 */
+	public String getInitiatorType() {
+		return initiatorType;
+	}
+
+	/**
+	 * リソース取得の契機の種別を設定します。
+	 * 
+	 * @param initiatorType リソース取得の契機の種別
+	 */
+	public void setInitiatorType(String initiatorType) {
+		this.initiatorType = initiatorType;
+	}
+
+	/**
+	 * リソース取得に用いられたネットワークプロトコルを取得します。
+	 * 
+	 * @return リソース取得に用いられたネットワークプロトコル
+	 */
+	public String getNextHopProtocol() {
+		return nextHopProtocol;
+	}
+
+	/**
+	 * リソース取得に用いられたネットワークプロトコルを設定します。
+	 * 
+	 * @param nextHopProtocol リソース取得に用いられたネットワークプロトコル
+	 */
+	public void setNextHopProtocol(String nextHopProtocol) {
+		this.nextHopProtocol = nextHopProtocol;
+	}
+
+	/**
+	 * 最後のリダイレクトの完了時間を取得します。
+	 * 
+	 * @return 最後のリダイレクトの完了時間
+	 */
+	public double getRedirectEnd() {
+		return redirectEnd;
+	}
+
+	/**
+	 * 最後のリダイレクトの完了時間を設定します。
+	 * 
+	 * @param redirectEnd 最後のリダイレクトの完了時間
+	 */
+	public void setRedirectEnd(double redirectEnd) {
+		this.redirectEnd = redirectEnd;
+	}
+
+	/**
+	 * リダイレクトの開始時間を取得します。
+	 * 
+	 * @return リダイレクトの開始時間
+	 */
+	public double getRedirectStart() {
+		return redirectStart;
+	}
+
+	/**
+	 * リダイレクトの開始時間を取得します。
+	 * 
+	 * @param redirectStart リダイレクトの開始時間
+	 */
+	public void setRedirectStart(double redirectStart) {
+		this.redirectStart = redirectStart;
+	}
+
+	/**
+	 * ブラウザからサーバへのリクエスト開始時間を取得します。
+	 * 
+	 * @return ブラウザからサーバへのリクエスト開始時間
+	 */
+	public double getRequestStart() {
+		return requestStart;
+	}
+
+	/**
+	 * ブラウザからサーバへのリクエスト開始時間を設定します。
+	 * 
+	 * @param requestStart ブラウザからサーバへのリクエスト開始時間
+	 */
+	public void setRequestStart(double requestStart) {
+		this.requestStart = requestStart;
+	}
+
+	/**
+	 * リソースのデータ受信完了時間を取得します。
+	 * 
+	 * @return リソースのデータ受信完了時間
+	 */
+	public double getResponseEnd() {
+		return responseEnd;
+	}
+
+	/**
+	 * リソースのデータ受信完了時間を設定します。
+	 * 
+	 * @param responseEnd リソースのデータ受信完了時間
+	 */
+	public void setResponseEnd(double responseEnd) {
+		this.responseEnd = responseEnd;
+	}
+
+	/**
+	 * リソースのデータ受信開始時間を取得します。
+	 * 
+	 * @return リソースのデータ受信開始時間
+	 */
+	public double getResponseStart() {
+		return responseStart;
+	}
+
+	/**
+	 * リソースのデータ受信開始時間を設定します。
+	 * 
+	 * @param responseStart リソースのデータ受信開始時間
+	 */
+	public void setResponseStart(double responseStart) {
+		this.responseStart = responseStart;
+	}
+
+	/**
+	 * セキュアな接続のハンドシェイク開始時間を取得します。
+	 * 
+	 * @return セキュアな接続のハンドシェイク開始時間
+	 */
+	public double getSecureConnectionStart() {
+		return secureConnectionStart;
+	}
+
+	/**
+	 * セキュアな接続のハンドシェイク開始時間を設定します。
+	 * 
+	 * @param secureConnectionStart セキュアな接続のハンドシェイク開始時間
+	 */
+	public void setSecureConnectionStart(double secureConnectionStart) {
+		this.secureConnectionStart = secureConnectionStart;
+	}
+
+	/**
+	 * リソースの転送にかかった受信バイト数を取得します。
+	 * 
+	 * @return リソースの転送にかかった受信バイト数
+	 */
+	public long getTransferSize() {
+		return transferSize;
+	}
+
+	/**
+	 * リソースの転送にかかった受信バイト数を設定します。
+	 * 
+	 * @param transferSize リソースの転送にかかった受信バイト数
+	 */
+	public void setTransferSize(long transferSize) {
+		this.transferSize = transferSize;
+	}
+
+	/**
+	 * Service Workerがリソース要求への割り込みを開始した時間を取得します。
+	 * <p>
+	 * Service Workerが稼働していなければfetchStartの直後です。 Service Workerがリソース要求への割り込みを行わなかった場合は0です。
+	 * </p>
+	 * 
+	 * @return Service Workerがリソース要求への割り込みを開始した時間
+	 */
+	public double getWorkerStart() {
+		return workerStart;
+	}
+
+	/**
+	 * Service Workerがリソース要求への割り込みを開始した時間を設定します。
+	 * 
+	 * @param workerStart Service Workerがリソース要求への割り込みを開始した時間
+	 */
+	public void setWorkerStart(double workerStart) {
+		this.workerStart = workerStart;
+	}
+}

--- a/pitalium/src/main/java/com/htmlhifive/pitalium/core/model/PerformanceTiming.java
+++ b/pitalium/src/main/java/com/htmlhifive/pitalium/core/model/PerformanceTiming.java
@@ -1,0 +1,431 @@
+package com.htmlhifive.pitalium.core.model;
+
+/**
+ * Navigation Timingを保持するクラス。
+ */
+public class PerformanceTiming {
+
+	private long navigationStart;
+	private long domainLookupStart;
+	private long domainLookupEnd;
+	private long connectStart;
+	private long connectEnd;
+	private long fetchStart;
+	private long requestStart;
+	private long domLoading;
+	private long domComplete;
+	private long domInteractive;
+	private long loadEventStart;
+	private long loadEventEnd;
+	private long domContentLoadedEventStart;
+	private long domContentLoadedEventEnd;
+	private long responseStart;
+	private long responseEnd;
+	private long redirectStart;
+	private long redirectEnd;
+	private long secureConnectionStart;
+	private long unloadEventStart;
+	private long unloadEventEnd;
+
+	/**
+	 * 空のオブジェクトを生成します。
+	 */
+	/**
+	 * 
+	 */
+	public PerformanceTiming() {
+	}
+
+	/**
+	 * 前のドキュメントのunloadイベントの開始時間を取得します。
+	 * 
+	 * @return 前のドキュメントのunloadイベントの開始時間
+	 */
+	public long getUnloadEventStart() {
+		return unloadEventStart;
+	}
+
+	/**
+	 * 前のドキュメントのunloadイベントの開始時間を設定します。
+	 * 
+	 * @param unloadEventStart 前のドキュメントのunloadイベントの開始時間
+	 */
+	public void setUnloadEventStart(long unloadEventStart) {
+		this.unloadEventStart = unloadEventStart;
+	}
+
+	/**
+	 * 前のドキュメントのunloadイベントの完了時間を取得します。
+	 * 
+	 * @return 前のドキュメントのunloadイベントの完了時間
+	 */
+	public long getUnloadEventEnd() {
+		return unloadEventEnd;
+	}
+
+	/**
+	 * 前のドキュメントのunloadイベントの完了時間を設定します。
+	 * 
+	 * @param unloadEventEnd 前のドキュメントのunloadイベントの完了時間
+	 */
+	public void setUnloadEventEnd(long unloadEventEnd) {
+		this.unloadEventEnd = unloadEventEnd;
+	}
+
+	/**
+	 * 前のドキュメントがあればunload完了時間、なければドキュメントの取得準備ができた時間を取得します。
+	 * 
+	 * @return 前のドキュメントがあればunload完了時間、なければドキュメントの取得準備ができた時間
+	 */
+	public long getNavigationStart() {
+		return navigationStart;
+	}
+
+	/**
+	 * 前のドキュメントがあればunload完了時間、なければドキュメントの取得準備ができた時間を設定します。
+	 * 
+	 * @param navigationStart 前のドキュメントがあればunload完了時間、なければドキュメントの取得準備ができた時間
+	 */
+	public void setNavigationStart(long navigationStart) {
+		this.navigationStart = navigationStart;
+	}
+
+	/**
+	 * リダイレクト開始時間を取得します。
+	 * <p>
+	 * リダイレクトがないか、オリジンが異なるリダイレクトがあれば0となります。
+	 * </p>
+	 * 
+	 * @return リダイレクト開始時間
+	 */
+	public long getRedirectStart() {
+		return redirectStart;
+	}
+
+	/**
+	 * リダイレクト開始時間を設定します。
+	 * 
+	 * @param redirectStart リダイレクト開始時間
+	 */
+	public void setRedirectStart(long redirectStart) {
+		this.redirectStart = redirectStart;
+	}
+
+	/**
+	 * 最後のリダイレクトの完了時間を取得します。
+	 * <p>
+	 * リダイレクトがないか、オリジンが異なるリダイレクトがあれば0です。
+	 * </p>
+	 * 
+	 * @return 最後のリダイレクトの完了時間
+	 */
+	public long getRedirectEnd() {
+		return redirectEnd;
+	}
+
+	/**
+	 * 最後のリダイレクトの完了時間を設定します。
+	 * 
+	 * @param redirectEnd 最後のリダイレクトの完了時間
+	 */
+	public void setRedirectEnd(long redirectEnd) {
+		this.redirectEnd = redirectEnd;
+	}
+
+	/**
+	 * セキュアな接続のハンドシェイク開始時間を取得します。
+	 * <p>
+	 * セキュアな接続がなければ0です。
+	 * </p>
+	 * 
+	 * @return セキュアな接続のハンドシェイク開始時間
+	 */
+	public long getSecureConnectionStart() {
+		return secureConnectionStart;
+	}
+
+	/**
+	 * セキュアな接続のハンドシェイク開始時間を設定します。
+	 * 
+	 * @param secureConnectionStart セキュアな接続のハンドシェイク開始時間
+	 */
+	public void setSecureConnectionStart(long secureConnectionStart) {
+		this.secureConnectionStart = secureConnectionStart;
+	}
+
+	/**
+	 * ブラウザによるリソースの名前解決開始時間を取得します。
+	 * 
+	 * @return ブラウザによるリソースの名前解決開始時間
+	 */
+	public long getDomainLookupStart() {
+		return domainLookupStart;
+	}
+
+	/**
+	 * ブラウザによるリソースの名前解決開始時間を設定します。
+	 * 
+	 * @param domainLookupStart ブラウザによるリソースの名前解決開始時間
+	 */
+	public void setDomainLookupStart(long domainLookupStart) {
+		this.domainLookupStart = domainLookupStart;
+	}
+
+	/**
+	 * ブラウザによるリソースの名前解決完了時間を取得します。
+	 * 
+	 * @return ブラウザによるリソースの名前解決完了時間
+	 */
+	public long getDomainLookupEnd() {
+		return domainLookupEnd;
+	}
+
+	/**
+	 * ブラウザによるリソースの名前解決完了時間を設定します。
+	 * 
+	 * @param domainLookupEnd ブラウザによるリソースの名前解決完了時間
+	 */
+	public void setDomainLookupEnd(long domainLookupEnd) {
+		this.domainLookupEnd = domainLookupEnd;
+	}
+
+	/**
+	 * ブラウザからサーバへの接続開始時間を取得します。
+	 * <p>
+	 * トランスポート層でエラーが発生し接続確立を再開した場合は、最後の接続開始時間を表します。
+	 * </p>
+	 * 
+	 * @return ブラウザからサーバへの接続開始時間
+	 */
+	public long getConnectStart() {
+		return connectStart;
+	}
+
+	/**
+	 * ブラウザからサーバへの接続開始時間を設定します。
+	 * 
+	 * @param connectStart ブラウザからサーバへの接続開始時間
+	 */
+	public void setConnectStart(long connectStart) {
+		this.connectStart = connectStart;
+	}
+
+	/**
+	 * ブラウザからサーバへの接続確立完了時間を取得します。
+	 * 
+	 * @return ブラウザからサーバへの接続確立完了時間
+	 */
+	public long getConnectEnd() {
+		return connectEnd;
+	}
+
+	/**
+	 * ブラウザからサーバへの接続確立完了時間を設定します。
+	 * 
+	 * @param connectEnd ブラウザからサーバへの接続確立完了時間
+	 */
+	public void setConnectEnd(long connectEnd) {
+		this.connectEnd = connectEnd;
+	}
+
+	/**
+	 * ドキュメントの取得準備ができた時間を取得します。
+	 * 
+	 * @return ドキュメントの取得準備ができた時間
+	 */
+	public long getFetchStart() {
+		return fetchStart;
+	}
+
+	/**
+	 * ドキュメントの取得準備ができた時間を設定します。
+	 * 
+	 * @param fetchStart ドキュメントの取得準備ができた時間
+	 */
+	public void setFetchStart(long fetchStart) {
+		this.fetchStart = fetchStart;
+	}
+
+	/**
+	 * ブラウザからサーバへのリクエスト開始時間を取得します。
+	 * <p>
+	 * トランスポート層でエラーが発生し接続が再開された場合は、新しい方のリクエストの開始時間を表します。
+	 * </p>
+	 * 
+	 * @return ブラウザからサーバへのリクエスト開始時間
+	 */
+	public long getRequestStart() {
+		return requestStart;
+	}
+
+	/**
+	 * ブラウザからサーバへのリクエスト開始時間を設定します。
+	 * 
+	 * @param requestStart ブラウザからサーバへのリクエスト開始時間
+	 */
+	public void setRequestStart(long requestStart) {
+		this.requestStart = requestStart;
+	}
+
+	/**
+	 * HTML解析の開始時間を取得します。
+	 * 
+	 * @return HTML解析の開始時間
+	 */
+	public long getDomLoading() {
+		return domLoading;
+	}
+
+	/**
+	 * HTML解析の開始時間を設定します。
+	 * 
+	 * @param domLoading HTML解析の開始時間
+	 */
+	public void setDomLoading(long domLoading) {
+		this.domLoading = domLoading;
+	}
+
+	/**
+	 * ドキュメント内のリソース読込完了時間を取得します。
+	 * 
+	 * @return ドキュメント内のリソース読込完了時間
+	 */
+	public long getDomComplete() {
+		return domComplete;
+	}
+
+	/**
+	 * ドキュメント内のリソース読込完了時間を設定します。
+	 * 
+	 * @param domComplete ドキュメント内のリソース読込完了時間
+	 */
+	public void setDomComplete(long domComplete) {
+		this.domComplete = domComplete;
+	}
+
+	/**
+	 * HTML解析の完了時間を取得します。
+	 * 
+	 * @return HTML解析の完了時間
+	 */
+	public long getDomInteractive() {
+		return domInteractive;
+	}
+
+	/**
+	 * HTML解析の完了時間を設定します。
+	 * 
+	 * @param domInteractive HTML解析の完了時間
+	 */
+	public void setDomInteractive(long domInteractive) {
+		this.domInteractive = domInteractive;
+	}
+
+	/**
+	 * loadイベントの開始時間を取得します。
+	 * 
+	 * @return loadイベントの開始時間
+	 */
+	public long getLoadEventStart() {
+		return loadEventStart;
+	}
+
+	/**
+	 * loadイベントの開始時間を設定します。
+	 * 
+	 * @param loadEventStart loadイベントの開始時間
+	 */
+	public void setLoadEventStart(long loadEventStart) {
+		this.loadEventStart = loadEventStart;
+	}
+
+	/**
+	 * loadイベントの完了時間を取得します。
+	 * 
+	 * @return loadイベントの完了時間
+	 */
+	public long getLoadEventEnd() {
+		return loadEventEnd;
+	}
+
+	/**
+	 * loadイベントの完了時間を設定します。
+	 * 
+	 * @param loadEventEnd loadイベントの完了時間
+	 */
+	public void setLoadEventEnd(long loadEventEnd) {
+		this.loadEventEnd = loadEventEnd;
+	}
+
+	/**
+	 * DOMContentLoadedイベントの開始時間を取得します。
+	 * 
+	 * @return DOMContentLoadedイベントの開始時間
+	 */
+	public long getDomContentLoadedEventStart() {
+		return domContentLoadedEventStart;
+	}
+
+	/**
+	 * DOMContentLoadedイベントの開始時間を設定します。
+	 * 
+	 * @param domContentLoadedEventStart DOMContentLoadedイベントの開始時間
+	 */
+	public void setDomContentLoadedEventStart(long domContentLoadedEventStart) {
+		this.domContentLoadedEventStart = domContentLoadedEventStart;
+	}
+
+	/**
+	 * DOMContentLoadedイベントの完了時間を取得します。
+	 * 
+	 * @return DOMContentLoadedイベントの完了時間
+	 */
+	public long getDomContentLoadedEventEnd() {
+		return domContentLoadedEventEnd;
+	}
+
+	/**
+	 * DOMContentLoadedイベントの完了時間を設定します。
+	 * 
+	 * @param domContentLoadedEventEnd DOMContentLoadedイベントの完了時間
+	 */
+	public void setDomContentLoadedEventEnd(long domContentLoadedEventEnd) {
+		this.domContentLoadedEventEnd = domContentLoadedEventEnd;
+	}
+
+	/**
+	 * レスポンスの最初のデータの受信時間を取得します。
+	 * 
+	 * @return レスポンスの最初のデータの受信時間
+	 */
+	public long getResponseStart() {
+		return responseStart;
+	}
+
+	/**
+	 * レスポンスの最初のデータの受信時間を設定します。
+	 * 
+	 * @param responseStart レスポンスの最初のデータの受信時間
+	 */
+	public void setResponseStart(long responseStart) {
+		this.responseStart = responseStart;
+	}
+
+	/**
+	 * レスポンスのデータの受信完了時間を取得します。
+	 * 
+	 * @return レスポンスのデータの受信完了時間
+	 */
+	public long getResponseEnd() {
+		return responseEnd;
+	}
+
+	/**
+	 * レスポンスのデータの受信完了時間を設定します。
+	 * 
+	 * @param responseEnd レスポンスのデータの受信完了時間
+	 */
+	public void setResponseEnd(long responseEnd) {
+		this.responseEnd = responseEnd;
+	}
+}

--- a/pitalium/src/main/java/com/htmlhifive/pitalium/core/rules/PerformanceTelemetry.java
+++ b/pitalium/src/main/java/com/htmlhifive/pitalium/core/rules/PerformanceTelemetry.java
@@ -1,0 +1,169 @@
+package com.htmlhifive.pitalium.core.rules;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.Context;
+import org.thymeleaf.context.IContext;
+import org.thymeleaf.templateresolver.ClassLoaderTemplateResolver;
+import org.thymeleaf.templateresolver.TemplateResolver;
+
+import com.htmlhifive.pitalium.common.exception.TestRuntimeException;
+import com.htmlhifive.pitalium.core.config.FilePersisterConfig;
+import com.htmlhifive.pitalium.core.config.PtlTestConfig;
+import com.htmlhifive.pitalium.core.io.FileNameFormatter;
+import com.htmlhifive.pitalium.core.io.PersistMetadata;
+import com.htmlhifive.pitalium.core.model.Performance;
+import com.htmlhifive.pitalium.core.result.TestResultManager;
+import com.htmlhifive.pitalium.core.selenium.PtlCapabilities;
+import com.htmlhifive.pitalium.core.selenium.TelemetricWebDriver;
+
+/**
+ * 性能測定結果の記録を行うRule用クラスです。 {@link com.htmlhifive.pitalium.core.TelemetricTestBase}を拡張した場合は、既に定義済みのため指定する必要はありません。
+ */
+public class PerformanceTelemetry extends TestWatcher {
+
+	private static final Logger LOG = LoggerFactory.getLogger(PerformanceTelemetry.class);
+
+	private TelemetricWebDriver telemetricWebDriver;
+
+	private String className;
+	private String methodName;
+	private String currentId;
+	private PtlCapabilities capabilities;
+	private List<Performance> performanceResults = new ArrayList<Performance>();
+	private String reportTemplateName = "detail";
+	private TemplateEngine templateEngine = createTemplateEngine();
+
+	@Override
+	protected void starting(Description desc) {
+		className = desc.getTestClass().getSimpleName();
+		methodName = desc.getMethodName().split("\\[")[0];
+		currentId = TestResultManager.getInstance().getCurrentId();
+	}
+
+	@Override
+	protected void finished(Description desc) {
+		measurePerformance();
+		writeDetails(getDetailFile());
+	}
+
+	private String makeDetailFileName() {
+		FilePersisterConfig config = PtlTestConfig.getInstance().getPersisterConfig().getFile();
+		PersistMetadata metadata = new PersistMetadata(currentId, className, methodName, "performance", capabilities);
+		FileNameFormatter fileNameFormatter = new FileNameFormatter(config.getTargetResultFileName());
+		return config.getResultDirectory() + File.separator + metadata.getExpectedId() + File.separator
+				+ metadata.getClassName() + File.separator
+				+ fileNameFormatter.format(metadata).replaceAll("\\..+$", ".html");
+
+	}
+
+	private File getDetailFile() {
+		File file = new File(makeDetailFileName());
+		File parent = file.getParentFile();
+		if (!parent.exists() && !parent.mkdirs()) {
+			throw new TestRuntimeException(String.format(Locale.US, "mkdir error \"%s\"", parent));
+		}
+		if (!parent.canWrite()) {
+			throw new TestRuntimeException(String.format(Locale.US, "No write permission at \"%s\"", parent));
+		}
+		return file;
+	}
+
+	private void writeDetails(File file) {
+		try (PrintWriter writer = new PrintWriter(file)) {
+			IContext context = new Context();
+			context.getVariables().put("performanceResults", performanceResults);
+			templateEngine.process(reportTemplateName, context, writer);
+		} catch (FileNotFoundException e) {
+			LOG.info("[Testcase warning] skip writing performance details", e);
+		}
+	}
+
+	private TemplateEngine createTemplateEngine() {
+		TemplateEngine engine = new TemplateEngine();
+		TemplateResolver resolver = new ClassLoaderTemplateResolver();
+		resolver.setTemplateMode("XHTML");
+		resolver.setPrefix("templates/");
+		resolver.setSuffix(".html");
+		resolver.setCharacterEncoding("UTF-8");
+		engine.setTemplateResolver(resolver);
+		return engine;
+	}
+
+	/**
+	 * 性能測定結果のレポートのテンプレート名を設定します。
+	 * 
+	 * @param reportTemplateName 性能測定結果のレポートのテンプレート名
+	 */
+	public void setReportTemplateName(String reportTemplateName) {
+		this.reportTemplateName = reportTemplateName;
+	}
+
+	/**
+	 * 性能を測定します。
+	 */
+	public void measurePerformance() {
+		measurePerformance(null);
+	}
+
+	/**
+	 * 性能を測定します。
+	 * 
+	 * @param label 性能測定結果のラベル
+	 */
+	public void measurePerformance(String label) {
+		if (telemetricWebDriver == null) {
+			throw new IllegalStateException("TelemetricWebDriver is not set");
+		}
+		telemetricWebDriver.measurePerformance(label);
+	}
+
+	/**
+	 * 性能測定結果を記録に追加します。追加済みの性能測定結果であった場合は更新します。
+	 * 
+	 * @param performance 性能測定結果
+	 */
+	public void addPerformance(Performance performance) {
+		if (performance.getLabel() == null) {
+			performance.setLabel(performance.getUrl());
+		}
+		performance.setId(String.valueOf(performance.getNavigationTiming().getNavigationStart()));
+
+		for (Performance result : performanceResults) {
+			if (result.getId().equals(performance.getId())) {
+				result.updateWith(performance);
+				return;
+			}
+		}
+		performanceResults.add(performance);
+	}
+
+	/**
+	 * 性能測定機能を持つWebDriverを設定します。
+	 * 
+	 * @param telemetricWebDriver 性能測定機能を持つWebDriver
+	 */
+	public void setTelemetricWebDriver(TelemetricWebDriver telemetricWebDriver) {
+		this.telemetricWebDriver = telemetricWebDriver;
+	}
+
+	/**
+	 * ブラウザスペック情報を設定します。
+	 * 
+	 * @param capabilities ブラウザスペック情報
+	 */
+	public void setCapabilities(PtlCapabilities capabilities) {
+		this.capabilities = capabilities;
+	}
+
+}

--- a/pitalium/src/main/java/com/htmlhifive/pitalium/core/selenium/PtlWebDriverFactory.java
+++ b/pitalium/src/main/java/com/htmlhifive/pitalium/core/selenium/PtlWebDriverFactory.java
@@ -56,6 +56,7 @@ import com.google.gson.JsonParser;
 import com.google.gson.JsonSyntaxException;
 import com.htmlhifive.pitalium.common.exception.TestRuntimeException;
 import com.htmlhifive.pitalium.core.config.EnvironmentConfig;
+import com.htmlhifive.pitalium.core.config.PerformanceMeasurementMode;
 import com.htmlhifive.pitalium.core.config.PtlTestConfig;
 import com.htmlhifive.pitalium.core.config.TestAppConfig;
 import com.htmlhifive.pitalium.core.config.WebDriverSessionLevel;
@@ -502,7 +503,11 @@ public abstract class PtlWebDriverFactory {
 
 		@Override
 		public PtlWebDriver createWebDriver(URL url) {
-			return new PtlFirefoxDriver(url, getCapabilities());
+			if (getEnvironmentConfig().getPerformanceMeasurementMode() == PerformanceMeasurementMode.OFF) {
+				return new PtlFirefoxDriver(url, getCapabilities());
+			} else {
+				return new TelemetricFirefoxDriver(url, getCapabilities());
+			}
 		}
 
 		@Override
@@ -535,7 +540,11 @@ public abstract class PtlWebDriverFactory {
 
 		@Override
 		public PtlWebDriver createWebDriver(URL url) {
-			return new PtlChromeDriver(url, getCapabilities());
+			if (getEnvironmentConfig().getPerformanceMeasurementMode() == PerformanceMeasurementMode.OFF) {
+				return new PtlChromeDriver(url, getCapabilities());
+			} else {
+				return new TelemetricChromeDriver(url, getCapabilities());
+			}
 		}
 
 		@Override
@@ -577,7 +586,11 @@ public abstract class PtlWebDriverFactory {
 
 		@Override
 		public PtlWebDriver createWebDriver(URL url) {
-			return new PtlInternetExplorerDriver(url, getCapabilities());
+			if (getEnvironmentConfig().getPerformanceMeasurementMode() == PerformanceMeasurementMode.OFF) {
+				return new PtlInternetExplorerDriver(url, getCapabilities());
+			} else {
+				return new TelemetricInternetExplorerDriver(url, getCapabilities());
+			}
 		}
 
 		@Override
@@ -605,7 +618,11 @@ public abstract class PtlWebDriverFactory {
 
 		@Override
 		public PtlWebDriver createWebDriver(URL url) {
-			return new PtlInternetExplorer7Driver(url, getCapabilities());
+			if (getEnvironmentConfig().getPerformanceMeasurementMode() == PerformanceMeasurementMode.OFF) {
+				return new PtlInternetExplorer7Driver(url, getCapabilities());
+			} else {
+				return new TelemetricInternetExplorer7Driver(url, getCapabilities());
+			}
 		}
 
 		@Override
@@ -633,7 +650,11 @@ public abstract class PtlWebDriverFactory {
 
 		@Override
 		public PtlWebDriver createWebDriver(URL url) {
-			return new PtlInternetExplorer8Driver(url, getCapabilities());
+			if (getEnvironmentConfig().getPerformanceMeasurementMode() == PerformanceMeasurementMode.OFF) {
+				return new PtlInternetExplorer8Driver(url, getCapabilities());
+			} else {
+				return new TelemetricInternetExplorer8Driver(url, getCapabilities());
+			}
 		}
 
 		@Override
@@ -666,7 +687,11 @@ public abstract class PtlWebDriverFactory {
 
 		@Override
 		public PtlWebDriver createWebDriver(URL url) {
-			return new PtlEdgeDriver(url, getCapabilities());
+			if (getEnvironmentConfig().getPerformanceMeasurementMode() == PerformanceMeasurementMode.OFF) {
+				return new PtlEdgeDriver(url, getCapabilities());
+			} else {
+				return new TelemetricEdgeDriver(url, getCapabilities());
+			}
 		}
 
 		@Override
@@ -699,7 +724,11 @@ public abstract class PtlWebDriverFactory {
 
 		@Override
 		public PtlWebDriver createWebDriver(URL url) {
-			return new PtlSafariDriver(url, getCapabilities());
+			if (getEnvironmentConfig().getPerformanceMeasurementMode() == PerformanceMeasurementMode.OFF) {
+				return new PtlSafariDriver(url, getCapabilities());
+			} else {
+				return new TelemetricSafariDriver(url, getCapabilities());
+			}
 		}
 
 		@Override
@@ -750,7 +779,11 @@ public abstract class PtlWebDriverFactory {
 
 		@Override
 		public PtlWebDriver createWebDriver(URL url) {
-			return new PtlIPhoneDriver(url, getCapabilities());
+			if (getEnvironmentConfig().getPerformanceMeasurementMode() == PerformanceMeasurementMode.OFF) {
+				return new PtlIPhoneDriver(url, getCapabilities());
+			} else {
+				return new TelemetricIPhoneDriver(url, getCapabilities());
+			}
 		}
 
 		@Override
@@ -800,7 +833,11 @@ public abstract class PtlWebDriverFactory {
 
 		@Override
 		public PtlWebDriver createWebDriver(URL url) {
-			return new PtlIPadDriver(url, getCapabilities());
+			if (getEnvironmentConfig().getPerformanceMeasurementMode() == PerformanceMeasurementMode.OFF) {
+				return new PtlIPadDriver(url, getCapabilities());
+			} else {
+				return new TelemetricIPadDriver(url, getCapabilities());
+			}
 		}
 
 		@Override
@@ -833,7 +870,11 @@ public abstract class PtlWebDriverFactory {
 
 		@Override
 		public PtlWebDriver createWebDriver(URL url) {
-			return new PtlAndroidDriver(url, getCapabilities());
+			if (getEnvironmentConfig().getPerformanceMeasurementMode() == PerformanceMeasurementMode.OFF) {
+				return new PtlAndroidDriver(url, getCapabilities());
+			} else {
+				return new TelemetricAndroidDriver(url, getCapabilities());
+			}
 		}
 
 		@Override
@@ -861,7 +902,11 @@ public abstract class PtlWebDriverFactory {
 
 		@Override
 		public PtlWebDriver createWebDriver(URL url) {
-			return new PtlSelendroidDriver(url, getCapabilities());
+			if (getEnvironmentConfig().getPerformanceMeasurementMode() == PerformanceMeasurementMode.OFF) {
+				return new PtlSelendroidDriver(url, getCapabilities());
+			} else {
+				return new TelemetricSelendroidDriver(url, getCapabilities());
+			}
 		}
 
 		@Override

--- a/pitalium/src/main/java/com/htmlhifive/pitalium/core/selenium/TelemetricAndroidDriver.java
+++ b/pitalium/src/main/java/com/htmlhifive/pitalium/core/selenium/TelemetricAndroidDriver.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright (C) 2015-2017 NS Solutions Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.htmlhifive.pitalium.core.selenium;
+
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import com.htmlhifive.pitalium.core.model.Performance;
+import com.htmlhifive.pitalium.core.rules.PerformanceTelemetry;
+
+/**
+ * Android端末で利用する{@link org.openqa.selenium.WebDriver}。Appium + Chrome向け。
+ */
+class TelemetricAndroidDriver extends PtlAndroidDriver implements TelemetricWebDriver {
+	private PerformanceTelemetry measure;
+
+	/**
+	 * コンストラクタ
+	 * 
+	 * @param remoteAddress RemoteWebDriverServerのアドレス
+	 * @param capabilities Capability
+	 */
+	TelemetricAndroidDriver(URL remoteAddress, PtlCapabilities capabilities) {
+		super(remoteAddress, capabilities);
+	}
+
+	@Override
+	public void get(String url) {
+		measurePerformance(null);
+		super.get(url);
+	}
+
+	@Override
+	public WebElement findElement(By by) {
+		return new TelemetricWebElement(super.findElement(by), this);
+	}
+
+	@Override
+	public WebElement findElementByClassName(String using) {
+		return new TelemetricWebElement(super.findElementByClassName(using), this);
+	}
+
+	@Override
+	public WebElement findElementByCssSelector(String using) {
+		return new TelemetricWebElement(super.findElementByCssSelector(using), this);
+	}
+
+	@Override
+	public WebElement findElementById(String using) {
+		return new TelemetricWebElement(super.findElementById(using), this);
+	}
+
+	@Override
+	public WebElement findElementByLinkText(String using) {
+		return new TelemetricWebElement(super.findElementByLinkText(using), this);
+	}
+
+	@Override
+	public WebElement findElementByName(String using) {
+		return new TelemetricWebElement(super.findElementByName(using), this);
+	}
+
+	@Override
+	public WebElement findElementByPartialLinkText(String using) {
+		return new TelemetricWebElement(super.findElementByPartialLinkText(using), this);
+	}
+
+	@Override
+	public WebElement findElementByTagName(String using) {
+		return new TelemetricWebElement(super.findElementByTagName(using), this);
+	}
+
+	@Override
+	public WebElement findElementByXPath(String using) {
+		return new TelemetricWebElement(super.findElementByXPath(using), this);
+	}
+
+	@Override
+	public List<WebElement> findElements(By by) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElements(by)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public List<WebElement> findElementsByClassName(String using) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElementsByClassName(using)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public List<WebElement> findElementsByCssSelector(String using) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElementsByCssSelector(using)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public List<WebElement> findElementsById(String using) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElementsById(using)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public List<WebElement> findElementsByLinkText(String using) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElementsByLinkText(using)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public List<WebElement> findElementsByName(String using) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElementsByName(using)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public List<WebElement> findElementsByPartialLinkText(String using) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElementsByPartialLinkText(using)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public List<WebElement> findElementsByTagName(String using) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElementsByTagName(using)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public List<WebElement> findElementsByXPath(String using) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElementsByXPath(using)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public void measurePerformance(String label) {
+		Performance performance = Performance.parseJson(executeJavaScript(SCRIPT));
+		performance.setBrowser(getCapabilities().getBrowserName());
+		performance.setLabel(label);
+		measure.addPerformance(performance);
+	}
+
+	@Override
+	public void setPerformanceMeasure(PerformanceTelemetry m) {
+		this.measure = m;
+	}
+}

--- a/pitalium/src/main/java/com/htmlhifive/pitalium/core/selenium/TelemetricChromeDriver.java
+++ b/pitalium/src/main/java/com/htmlhifive/pitalium/core/selenium/TelemetricChromeDriver.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright (C) 2015-2017 NS Solutions Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.htmlhifive.pitalium.core.selenium;
+
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import com.htmlhifive.pitalium.core.model.Performance;
+import com.htmlhifive.pitalium.core.rules.PerformanceTelemetry;
+
+/**
+ * Google Chromeで利用する{@link org.openqa.selenium.WebDriver}
+ */
+class TelemetricChromeDriver extends PtlChromeDriver implements TelemetricWebDriver {
+	private PerformanceTelemetry measure;
+
+	/**
+	 * コンストラクタ
+	 * 
+	 * @param remoteAddress RemoteWebDriverServerのアドレス
+	 * @param capabilities Capability
+	 */
+	TelemetricChromeDriver(URL remoteAddress, PtlCapabilities capabilities) {
+		super(remoteAddress, capabilities);
+	}
+
+	@Override
+	public void get(String url) {
+		measurePerformance(null);
+		super.get(url);
+	}
+
+	@Override
+	protected PtlWebElement newPtlWebElement() {
+		return new PtlChromeWebElement();
+	}
+
+	@Override
+	public WebElement findElement(By by) {
+		return new TelemetricWebElement(super.findElement(by), this);
+	}
+
+	@Override
+	public WebElement findElementByClassName(String using) {
+		return new TelemetricWebElement(super.findElementByClassName(using), this);
+	}
+
+	@Override
+	public WebElement findElementByCssSelector(String using) {
+		return new TelemetricWebElement(super.findElementByCssSelector(using), this);
+	}
+
+	@Override
+	public WebElement findElementById(String using) {
+		return new TelemetricWebElement(super.findElementById(using), this);
+	}
+
+	@Override
+	public WebElement findElementByLinkText(String using) {
+		return new TelemetricWebElement(super.findElementByLinkText(using), this);
+	}
+
+	@Override
+	public WebElement findElementByName(String using) {
+		return new TelemetricWebElement(super.findElementByName(using), this);
+	}
+
+	@Override
+	public WebElement findElementByPartialLinkText(String using) {
+		return new TelemetricWebElement(super.findElementByPartialLinkText(using), this);
+	}
+
+	@Override
+	public WebElement findElementByTagName(String using) {
+		return new TelemetricWebElement(super.findElementByTagName(using), this);
+	}
+
+	@Override
+	public WebElement findElementByXPath(String using) {
+		return new TelemetricWebElement(super.findElementByXPath(using), this);
+	}
+
+	@Override
+	public List<WebElement> findElements(By by) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElements(by)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public List<WebElement> findElementsByClassName(String using) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElementsByClassName(using)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public List<WebElement> findElementsByCssSelector(String using) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElementsByCssSelector(using)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public List<WebElement> findElementsById(String using) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElementsById(using)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public List<WebElement> findElementsByLinkText(String using) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElementsByLinkText(using)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public List<WebElement> findElementsByName(String using) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElementsByName(using)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public List<WebElement> findElementsByPartialLinkText(String using) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElementsByPartialLinkText(using)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public List<WebElement> findElementsByTagName(String using) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElementsByTagName(using)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public List<WebElement> findElementsByXPath(String using) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElementsByXPath(using)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public void measurePerformance(String label) {
+		Performance performance = Performance.parseJson(executeJavaScript(SCRIPT));
+		performance.setBrowser(getCapabilities().getBrowserName());
+		performance.setLabel(label);
+		measure.addPerformance(performance);
+	}
+
+	@Override
+	public void setPerformanceMeasure(PerformanceTelemetry m) {
+		this.measure = m;
+	}
+}

--- a/pitalium/src/main/java/com/htmlhifive/pitalium/core/selenium/TelemetricEdgeDriver.java
+++ b/pitalium/src/main/java/com/htmlhifive/pitalium/core/selenium/TelemetricEdgeDriver.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright (C) 2015-2017 NS Solutions Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.htmlhifive.pitalium.core.selenium;
+
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import com.htmlhifive.pitalium.core.model.Performance;
+import com.htmlhifive.pitalium.core.rules.PerformanceTelemetry;
+
+/**
+ * MicrosoftEdgeで利用する{@link org.openqa.selenium.WebDriver}
+ */
+class TelemetricEdgeDriver extends PtlEdgeDriver implements TelemetricWebDriver {
+	private PerformanceTelemetry measure;
+
+	/**
+	 * コンストラクタ
+	 * 
+	 * @param remoteAddress RemoteWebDriverServerのアドレス
+	 * @param capabilities Capability
+	 */
+	TelemetricEdgeDriver(URL remoteAddress, PtlCapabilities capabilities) {
+		super(remoteAddress, capabilities);
+	}
+
+	@Override
+	public void get(String url) {
+		measurePerformance(null);
+		super.get(url);
+	}
+
+	@Override
+	protected PtlWebElement newPtlWebElement() {
+		return new PtlEdgeWebElement();
+	}
+
+	@Override
+	public WebElement findElement(By by) {
+		return new TelemetricWebElement(super.findElement(by), this);
+	}
+
+	@Override
+	public WebElement findElementByClassName(String using) {
+		return new TelemetricWebElement(super.findElementByClassName(using), this);
+	}
+
+	@Override
+	public WebElement findElementByCssSelector(String using) {
+		return new TelemetricWebElement(super.findElementByCssSelector(using), this);
+	}
+
+	@Override
+	public WebElement findElementById(String using) {
+		return new TelemetricWebElement(super.findElementById(using), this);
+	}
+
+	@Override
+	public WebElement findElementByLinkText(String using) {
+		return new TelemetricWebElement(super.findElementByLinkText(using), this);
+	}
+
+	@Override
+	public WebElement findElementByName(String using) {
+		return new TelemetricWebElement(super.findElementByName(using), this);
+	}
+
+	@Override
+	public WebElement findElementByPartialLinkText(String using) {
+		return new TelemetricWebElement(super.findElementByPartialLinkText(using), this);
+	}
+
+	@Override
+	public WebElement findElementByTagName(String using) {
+		return new TelemetricWebElement(super.findElementByTagName(using), this);
+	}
+
+	@Override
+	public WebElement findElementByXPath(String using) {
+		return new TelemetricWebElement(super.findElementByXPath(using), this);
+	}
+
+	@Override
+	public List<WebElement> findElements(By by) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElements(by)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public List<WebElement> findElementsByClassName(String using) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElementsByClassName(using)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public List<WebElement> findElementsByCssSelector(String using) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElementsByCssSelector(using)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public List<WebElement> findElementsById(String using) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElementsById(using)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public List<WebElement> findElementsByLinkText(String using) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElementsByLinkText(using)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public List<WebElement> findElementsByName(String using) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElementsByName(using)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public List<WebElement> findElementsByPartialLinkText(String using) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElementsByPartialLinkText(using)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public List<WebElement> findElementsByTagName(String using) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElementsByTagName(using)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public List<WebElement> findElementsByXPath(String using) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElementsByXPath(using)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public void measurePerformance(String label) {
+		Performance performance = Performance.parseJson(executeJavaScript(SCRIPT));
+		performance.setBrowser(getCapabilities().getBrowserName());
+		performance.setLabel(label);
+		measure.addPerformance(performance);
+	}
+
+	@Override
+	public void setPerformanceMeasure(PerformanceTelemetry m) {
+		this.measure = m;
+	}
+}

--- a/pitalium/src/main/java/com/htmlhifive/pitalium/core/selenium/TelemetricFirefoxDriver.java
+++ b/pitalium/src/main/java/com/htmlhifive/pitalium/core/selenium/TelemetricFirefoxDriver.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright (C) 2015-2017 NS Solutions Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.htmlhifive.pitalium.core.selenium;
+
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import com.htmlhifive.pitalium.core.model.Performance;
+import com.htmlhifive.pitalium.core.rules.PerformanceTelemetry;
+
+/**
+ * Firefoxで利用する{@link org.openqa.selenium.WebDriver}
+ */
+class TelemetricFirefoxDriver extends PtlFirefoxDriver implements TelemetricWebDriver {
+	private PerformanceTelemetry measure;
+
+	/**
+	 * コンストラクタ
+	 * 
+	 * @param remoteAddress RemoteWebDriverServerのアドレス
+	 * @param capabilities Capability
+	 */
+	TelemetricFirefoxDriver(URL remoteAddress, PtlCapabilities capabilities) {
+		super(remoteAddress, capabilities);
+	}
+
+	@Override
+	public void get(String url) {
+		measurePerformance(null);
+		super.get(url);
+	}
+
+	@Override
+	public WebElement findElement(By by) {
+		return new TelemetricWebElement(super.findElement(by), this);
+	}
+
+	@Override
+	public WebElement findElementByClassName(String using) {
+		return new TelemetricWebElement(super.findElementByClassName(using), this);
+	}
+
+	@Override
+	public WebElement findElementByCssSelector(String using) {
+		return new TelemetricWebElement(super.findElementByCssSelector(using), this);
+	}
+
+	@Override
+	public WebElement findElementById(String using) {
+		return new TelemetricWebElement(super.findElementById(using), this);
+	}
+
+	@Override
+	public WebElement findElementByLinkText(String using) {
+		return new TelemetricWebElement(super.findElementByLinkText(using), this);
+	}
+
+	@Override
+	public WebElement findElementByName(String using) {
+		return new TelemetricWebElement(super.findElementByName(using), this);
+	}
+
+	@Override
+	public WebElement findElementByPartialLinkText(String using) {
+		return new TelemetricWebElement(super.findElementByPartialLinkText(using), this);
+	}
+
+	@Override
+	public WebElement findElementByTagName(String using) {
+		return new TelemetricWebElement(super.findElementByTagName(using), this);
+	}
+
+	@Override
+	public WebElement findElementByXPath(String using) {
+		return new TelemetricWebElement(super.findElementByXPath(using), this);
+	}
+
+	@Override
+	public List<WebElement> findElements(By by) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElements(by)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public List<WebElement> findElementsByClassName(String using) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElementsByClassName(using)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public List<WebElement> findElementsByCssSelector(String using) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElementsByCssSelector(using)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public List<WebElement> findElementsById(String using) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElementsById(using)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public List<WebElement> findElementsByLinkText(String using) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElementsByLinkText(using)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public List<WebElement> findElementsByName(String using) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElementsByName(using)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public List<WebElement> findElementsByPartialLinkText(String using) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElementsByPartialLinkText(using)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public List<WebElement> findElementsByTagName(String using) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElementsByTagName(using)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public List<WebElement> findElementsByXPath(String using) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElementsByXPath(using)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public void measurePerformance(String label) {
+		Performance performance = Performance.parseJson(executeJavaScript(SCRIPT));
+		performance.setBrowser(getCapabilities().getBrowserName());
+		performance.setLabel(label);
+		measure.addPerformance(performance);
+	}
+
+	@Override
+	public void setPerformanceMeasure(PerformanceTelemetry m) {
+		this.measure = m;
+	}
+}

--- a/pitalium/src/main/java/com/htmlhifive/pitalium/core/selenium/TelemetricIPadDriver.java
+++ b/pitalium/src/main/java/com/htmlhifive/pitalium/core/selenium/TelemetricIPadDriver.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright (C) 2015-2017 NS Solutions Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.htmlhifive.pitalium.core.selenium;
+
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import com.htmlhifive.pitalium.core.model.Performance;
+import com.htmlhifive.pitalium.core.rules.PerformanceTelemetry;
+
+/**
+ * iPadのSafariで利用する{@link org.openqa.selenium.WebDriver}
+ */
+class TelemetricIPadDriver extends PtlIPadDriver implements TelemetricWebDriver {
+	private PerformanceTelemetry measure;
+
+	/**
+	 * コンストラクタ
+	 * 
+	 * @param remoteAddress RemoteWebDriverServerのアドレス
+	 * @param capabilities Capability
+	 */
+	TelemetricIPadDriver(URL remoteAddress, PtlCapabilities capabilities) {
+		super(remoteAddress, capabilities);
+	}
+
+	@Override
+	public void get(String url) {
+		measurePerformance(null);
+		super.get(url);
+	}
+
+	@Override
+	public WebElement findElement(By by) {
+		return new TelemetricWebElement(super.findElement(by), this);
+	}
+
+	@Override
+	public WebElement findElementByClassName(String using) {
+		return new TelemetricWebElement(super.findElementByClassName(using), this);
+	}
+
+	@Override
+	public WebElement findElementByCssSelector(String using) {
+		return new TelemetricWebElement(super.findElementByCssSelector(using), this);
+	}
+
+	@Override
+	public WebElement findElementById(String using) {
+		return new TelemetricWebElement(super.findElementById(using), this);
+	}
+
+	@Override
+	public WebElement findElementByLinkText(String using) {
+		return new TelemetricWebElement(super.findElementByLinkText(using), this);
+	}
+
+	@Override
+	public WebElement findElementByName(String using) {
+		return new TelemetricWebElement(super.findElementByName(using), this);
+	}
+
+	@Override
+	public WebElement findElementByPartialLinkText(String using) {
+		return new TelemetricWebElement(super.findElementByPartialLinkText(using), this);
+	}
+
+	@Override
+	public WebElement findElementByTagName(String using) {
+		return new TelemetricWebElement(super.findElementByTagName(using), this);
+	}
+
+	@Override
+	public WebElement findElementByXPath(String using) {
+		return new TelemetricWebElement(super.findElementByXPath(using), this);
+	}
+
+	@Override
+	public List<WebElement> findElements(By by) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElements(by)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public List<WebElement> findElementsByClassName(String using) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElementsByClassName(using)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public List<WebElement> findElementsByCssSelector(String using) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElementsByCssSelector(using)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public List<WebElement> findElementsById(String using) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElementsById(using)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public List<WebElement> findElementsByLinkText(String using) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElementsByLinkText(using)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public List<WebElement> findElementsByName(String using) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElementsByName(using)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public List<WebElement> findElementsByPartialLinkText(String using) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElementsByPartialLinkText(using)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public List<WebElement> findElementsByTagName(String using) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElementsByTagName(using)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public List<WebElement> findElementsByXPath(String using) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElementsByXPath(using)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public void measurePerformance(String label) {
+		Performance performance = Performance.parseJson(executeJavaScript(SCRIPT));
+		performance.setBrowser(getCapabilities().getBrowserName());
+		performance.setLabel(label);
+		measure.addPerformance(performance);
+	}
+
+	@Override
+	public void setPerformanceMeasure(PerformanceTelemetry m) {
+		this.measure = m;
+	}
+}

--- a/pitalium/src/main/java/com/htmlhifive/pitalium/core/selenium/TelemetricIPhoneDriver.java
+++ b/pitalium/src/main/java/com/htmlhifive/pitalium/core/selenium/TelemetricIPhoneDriver.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright (C) 2015-2017 NS Solutions Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.htmlhifive.pitalium.core.selenium;
+
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import com.htmlhifive.pitalium.core.model.Performance;
+import com.htmlhifive.pitalium.core.rules.PerformanceTelemetry;
+
+/**
+ * iPhoneのSafariで利用する{@link org.openqa.selenium.WebDriver}
+ */
+class TelemetricIPhoneDriver extends PtlIPhoneDriver implements TelemetricWebDriver {
+	private PerformanceTelemetry measure;
+
+	/**
+	 * コンストラクタ
+	 * 
+	 * @param remoteAddress RemoteWebDriverServerのアドレス
+	 * @param capabilities Capability
+	 */
+	TelemetricIPhoneDriver(URL remoteAddress, PtlCapabilities capabilities) {
+		super(remoteAddress, capabilities);
+	}
+
+	@Override
+	public void get(String url) {
+		measurePerformance(null);
+		super.get(url);
+	}
+
+	@Override
+	public WebElement findElement(By by) {
+		return new TelemetricWebElement(super.findElement(by), this);
+	}
+
+	@Override
+	public WebElement findElementByClassName(String using) {
+		return new TelemetricWebElement(super.findElementByClassName(using), this);
+	}
+
+	@Override
+	public WebElement findElementByCssSelector(String using) {
+		return new TelemetricWebElement(super.findElementByCssSelector(using), this);
+	}
+
+	@Override
+	public WebElement findElementById(String using) {
+		return new TelemetricWebElement(super.findElementById(using), this);
+	}
+
+	@Override
+	public WebElement findElementByLinkText(String using) {
+		return new TelemetricWebElement(super.findElementByLinkText(using), this);
+	}
+
+	@Override
+	public WebElement findElementByName(String using) {
+		return new TelemetricWebElement(super.findElementByName(using), this);
+	}
+
+	@Override
+	public WebElement findElementByPartialLinkText(String using) {
+		return new TelemetricWebElement(super.findElementByPartialLinkText(using), this);
+	}
+
+	@Override
+	public WebElement findElementByTagName(String using) {
+		return new TelemetricWebElement(super.findElementByTagName(using), this);
+	}
+
+	@Override
+	public WebElement findElementByXPath(String using) {
+		return new TelemetricWebElement(super.findElementByXPath(using), this);
+	}
+
+	@Override
+	public List<WebElement> findElements(By by) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElements(by)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public List<WebElement> findElementsByClassName(String using) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElementsByClassName(using)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public List<WebElement> findElementsByCssSelector(String using) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElementsByCssSelector(using)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public List<WebElement> findElementsById(String using) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElementsById(using)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public List<WebElement> findElementsByLinkText(String using) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElementsByLinkText(using)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public List<WebElement> findElementsByName(String using) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElementsByName(using)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public List<WebElement> findElementsByPartialLinkText(String using) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElementsByPartialLinkText(using)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public List<WebElement> findElementsByTagName(String using) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElementsByTagName(using)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public List<WebElement> findElementsByXPath(String using) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElementsByXPath(using)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public void measurePerformance(String label) {
+		Performance performance = Performance.parseJson(executeJavaScript(SCRIPT));
+		performance.setBrowser(getCapabilities().getBrowserName());
+		performance.setLabel(label);
+		measure.addPerformance(performance);
+	}
+
+	@Override
+	public void setPerformanceMeasure(PerformanceTelemetry m) {
+		this.measure = m;
+	}
+}

--- a/pitalium/src/main/java/com/htmlhifive/pitalium/core/selenium/TelemetricInternetExplorer7Driver.java
+++ b/pitalium/src/main/java/com/htmlhifive/pitalium/core/selenium/TelemetricInternetExplorer7Driver.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright (C) 2015-2017 NS Solutions Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.htmlhifive.pitalium.core.selenium;
+
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import com.htmlhifive.pitalium.core.model.Performance;
+import com.htmlhifive.pitalium.core.rules.PerformanceTelemetry;
+
+/**
+ * Internet Explorer 7で利用する{@link org.openqa.selenium.WebDriver}
+ */
+class TelemetricInternetExplorer7Driver extends PtlInternetExplorer7Driver implements TelemetricWebDriver {
+	private PerformanceTelemetry measure;
+
+	/**
+	 * コンストラクタ
+	 * 
+	 * @param remoteAddress RemoteWebDriverServerのアドレス
+	 * @param capabilities Capability
+	 */
+	TelemetricInternetExplorer7Driver(URL remoteAddress, PtlCapabilities capabilities) {
+		super(remoteAddress, capabilities);
+	}
+
+	@Override
+	public void get(String url) {
+		measurePerformance(null);
+		super.get(url);
+	}
+
+	@Override
+	public WebElement findElement(By by) {
+		return new TelemetricWebElement(super.findElement(by), this);
+	}
+
+	@Override
+	public WebElement findElementByClassName(String using) {
+		return new TelemetricWebElement(super.findElementByClassName(using), this);
+	}
+
+	@Override
+	public WebElement findElementByCssSelector(String using) {
+		return new TelemetricWebElement(super.findElementByCssSelector(using), this);
+	}
+
+	@Override
+	public WebElement findElementById(String using) {
+		return new TelemetricWebElement(super.findElementById(using), this);
+	}
+
+	@Override
+	public WebElement findElementByLinkText(String using) {
+		return new TelemetricWebElement(super.findElementByLinkText(using), this);
+	}
+
+	@Override
+	public WebElement findElementByName(String using) {
+		return new TelemetricWebElement(super.findElementByName(using), this);
+	}
+
+	@Override
+	public WebElement findElementByPartialLinkText(String using) {
+		return new TelemetricWebElement(super.findElementByPartialLinkText(using), this);
+	}
+
+	@Override
+	public WebElement findElementByTagName(String using) {
+		return new TelemetricWebElement(super.findElementByTagName(using), this);
+	}
+
+	@Override
+	public WebElement findElementByXPath(String using) {
+		return new TelemetricWebElement(super.findElementByXPath(using), this);
+	}
+
+	@Override
+	public List<WebElement> findElements(By by) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElements(by)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public List<WebElement> findElementsByClassName(String using) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElementsByClassName(using)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public List<WebElement> findElementsByCssSelector(String using) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElementsByCssSelector(using)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public List<WebElement> findElementsById(String using) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElementsById(using)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public List<WebElement> findElementsByLinkText(String using) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElementsByLinkText(using)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public List<WebElement> findElementsByName(String using) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElementsByName(using)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public List<WebElement> findElementsByPartialLinkText(String using) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElementsByPartialLinkText(using)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public List<WebElement> findElementsByTagName(String using) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElementsByTagName(using)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public List<WebElement> findElementsByXPath(String using) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElementsByXPath(using)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public void measurePerformance(String label) {
+		Performance performance = Performance.parseJson(executeJavaScript(SCRIPT));
+		performance.setBrowser(getCapabilities().getBrowserName());
+		performance.setLabel(label);
+		measure.addPerformance(performance);
+	}
+
+	@Override
+	public void setPerformanceMeasure(PerformanceTelemetry m) {
+		this.measure = m;
+	}
+}

--- a/pitalium/src/main/java/com/htmlhifive/pitalium/core/selenium/TelemetricInternetExplorer8Driver.java
+++ b/pitalium/src/main/java/com/htmlhifive/pitalium/core/selenium/TelemetricInternetExplorer8Driver.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright (C) 2015-2017 NS Solutions Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.htmlhifive.pitalium.core.selenium;
+
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import com.htmlhifive.pitalium.core.model.Performance;
+import com.htmlhifive.pitalium.core.rules.PerformanceTelemetry;
+
+/**
+ * Internet Explorer 8で利用する{@link org.openqa.selenium.WebDriver}
+ */
+class TelemetricInternetExplorer8Driver extends PtlInternetExplorer8Driver implements TelemetricWebDriver {
+	private PerformanceTelemetry measure;
+
+	/**
+	 * コンストラクタ
+	 * 
+	 * @param remoteAddress RemoteWebDriverServerのアドレス
+	 * @param capabilities Capability
+	 */
+	TelemetricInternetExplorer8Driver(URL remoteAddress, PtlCapabilities capabilities) {
+		super(remoteAddress, capabilities);
+	}
+
+	@Override
+	public void get(String url) {
+		measurePerformance(null);
+		super.get(url);
+	}
+
+	@Override
+	public WebElement findElement(By by) {
+		return new TelemetricWebElement(super.findElement(by), this);
+	}
+
+	@Override
+	public WebElement findElementByClassName(String using) {
+		return new TelemetricWebElement(super.findElementByClassName(using), this);
+	}
+
+	@Override
+	public WebElement findElementByCssSelector(String using) {
+		return new TelemetricWebElement(super.findElementByCssSelector(using), this);
+	}
+
+	@Override
+	public WebElement findElementById(String using) {
+		return new TelemetricWebElement(super.findElementById(using), this);
+	}
+
+	@Override
+	public WebElement findElementByLinkText(String using) {
+		return new TelemetricWebElement(super.findElementByLinkText(using), this);
+	}
+
+	@Override
+	public WebElement findElementByName(String using) {
+		return new TelemetricWebElement(super.findElementByName(using), this);
+	}
+
+	@Override
+	public WebElement findElementByPartialLinkText(String using) {
+		return new TelemetricWebElement(super.findElementByPartialLinkText(using), this);
+	}
+
+	@Override
+	public WebElement findElementByTagName(String using) {
+		return new TelemetricWebElement(super.findElementByTagName(using), this);
+	}
+
+	@Override
+	public WebElement findElementByXPath(String using) {
+		return new TelemetricWebElement(super.findElementByXPath(using), this);
+	}
+
+	@Override
+	public List<WebElement> findElements(By by) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElements(by)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public List<WebElement> findElementsByClassName(String using) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElementsByClassName(using)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public List<WebElement> findElementsByCssSelector(String using) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElementsByCssSelector(using)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public List<WebElement> findElementsById(String using) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElementsById(using)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public List<WebElement> findElementsByLinkText(String using) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElementsByLinkText(using)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public List<WebElement> findElementsByName(String using) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElementsByName(using)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public List<WebElement> findElementsByPartialLinkText(String using) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElementsByPartialLinkText(using)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public List<WebElement> findElementsByTagName(String using) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElementsByTagName(using)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public List<WebElement> findElementsByXPath(String using) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElementsByXPath(using)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public void measurePerformance(String label) {
+		Performance performance = Performance.parseJson(executeJavaScript(SCRIPT));
+		performance.setBrowser(getCapabilities().getBrowserName());
+		performance.setLabel(label);
+		measure.addPerformance(performance);
+	}
+
+	@Override
+	public void setPerformanceMeasure(PerformanceTelemetry m) {
+		this.measure = m;
+	}
+}

--- a/pitalium/src/main/java/com/htmlhifive/pitalium/core/selenium/TelemetricInternetExplorerDriver.java
+++ b/pitalium/src/main/java/com/htmlhifive/pitalium/core/selenium/TelemetricInternetExplorerDriver.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright (C) 2015-2017 NS Solutions Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.htmlhifive.pitalium.core.selenium;
+
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import com.htmlhifive.pitalium.core.model.Performance;
+import com.htmlhifive.pitalium.core.rules.PerformanceTelemetry;
+
+/**
+ * Internet Explorerで利用する{@link org.openqa.selenium.WebDriver}
+ */
+class TelemetricInternetExplorerDriver extends PtlInternetExplorerDriver implements TelemetricWebDriver {
+	private PerformanceTelemetry measure;
+
+	/**
+	 * コンストラクタ
+	 * 
+	 * @param remoteAddress RemoteWebDriverServerのアドレス
+	 * @param capabilities Capability
+	 */
+	TelemetricInternetExplorerDriver(URL remoteAddress, PtlCapabilities capabilities) {
+		super(remoteAddress, capabilities);
+	}
+
+	@Override
+	public void get(String url) {
+		measurePerformance(null);
+		super.get(url);
+	}
+
+	@Override
+	public WebElement findElement(By by) {
+		return new TelemetricWebElement(super.findElement(by), this);
+	}
+
+	@Override
+	public WebElement findElementByClassName(String using) {
+		return new TelemetricWebElement(super.findElementByClassName(using), this);
+	}
+
+	@Override
+	public WebElement findElementByCssSelector(String using) {
+		return new TelemetricWebElement(super.findElementByCssSelector(using), this);
+	}
+
+	@Override
+	public WebElement findElementById(String using) {
+		return new TelemetricWebElement(super.findElementById(using), this);
+	}
+
+	@Override
+	public WebElement findElementByLinkText(String using) {
+		return new TelemetricWebElement(super.findElementByLinkText(using), this);
+	}
+
+	@Override
+	public WebElement findElementByName(String using) {
+		return new TelemetricWebElement(super.findElementByName(using), this);
+	}
+
+	@Override
+	public WebElement findElementByPartialLinkText(String using) {
+		return new TelemetricWebElement(super.findElementByPartialLinkText(using), this);
+	}
+
+	@Override
+	public WebElement findElementByTagName(String using) {
+		return new TelemetricWebElement(super.findElementByTagName(using), this);
+	}
+
+	@Override
+	public WebElement findElementByXPath(String using) {
+		return new TelemetricWebElement(super.findElementByXPath(using), this);
+	}
+
+	@Override
+	public List<WebElement> findElements(By by) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElements(by)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public List<WebElement> findElementsByClassName(String using) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElementsByClassName(using)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public List<WebElement> findElementsByCssSelector(String using) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElementsByCssSelector(using)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public List<WebElement> findElementsById(String using) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElementsById(using)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public List<WebElement> findElementsByLinkText(String using) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElementsByLinkText(using)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public List<WebElement> findElementsByName(String using) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElementsByName(using)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public List<WebElement> findElementsByPartialLinkText(String using) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElementsByPartialLinkText(using)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public List<WebElement> findElementsByTagName(String using) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElementsByTagName(using)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public List<WebElement> findElementsByXPath(String using) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElementsByXPath(using)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public void measurePerformance(String label) {
+		Performance performance = Performance.parseJson(executeJavaScript(SCRIPT));
+		performance.setBrowser(getCapabilities().getBrowserName());
+		performance.setLabel(label);
+		measure.addPerformance(performance);
+	}
+
+	@Override
+	public void setPerformanceMeasure(PerformanceTelemetry m) {
+		this.measure = m;
+	}
+}

--- a/pitalium/src/main/java/com/htmlhifive/pitalium/core/selenium/TelemetricSafariDriver.java
+++ b/pitalium/src/main/java/com/htmlhifive/pitalium/core/selenium/TelemetricSafariDriver.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright (C) 2015-2017 NS Solutions Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.htmlhifive.pitalium.core.selenium;
+
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import com.htmlhifive.pitalium.core.model.Performance;
+import com.htmlhifive.pitalium.core.rules.PerformanceTelemetry;
+
+/**
+ * Mac OS XのSafariで利用する{@link org.openqa.selenium.WebDriver}
+ */
+class TelemetricSafariDriver extends PtlSafariDriver implements TelemetricWebDriver {
+	private PerformanceTelemetry measure;
+
+	/**
+	 * コンストラクタ
+	 * 
+	 * @param remoteAddress RemoteWebDriverServerのアドレス
+	 * @param capabilities Capability
+	 */
+	TelemetricSafariDriver(URL remoteAddress, PtlCapabilities capabilities) {
+		super(remoteAddress, capabilities);
+	}
+
+	@Override
+	public void get(String url) {
+		measurePerformance(null);
+		super.get(url);
+	}
+
+	@Override
+	public WebElement findElement(By by) {
+		return new TelemetricWebElement(super.findElement(by), this);
+	}
+
+	@Override
+	public WebElement findElementByClassName(String using) {
+		return new TelemetricWebElement(super.findElementByClassName(using), this);
+	}
+
+	@Override
+	public WebElement findElementByCssSelector(String using) {
+		return new TelemetricWebElement(super.findElementByCssSelector(using), this);
+	}
+
+	@Override
+	public WebElement findElementById(String using) {
+		return new TelemetricWebElement(super.findElementById(using), this);
+	}
+
+	@Override
+	public WebElement findElementByLinkText(String using) {
+		return new TelemetricWebElement(super.findElementByLinkText(using), this);
+	}
+
+	@Override
+	public WebElement findElementByName(String using) {
+		return new TelemetricWebElement(super.findElementByName(using), this);
+	}
+
+	@Override
+	public WebElement findElementByPartialLinkText(String using) {
+		return new TelemetricWebElement(super.findElementByPartialLinkText(using), this);
+	}
+
+	@Override
+	public WebElement findElementByTagName(String using) {
+		return new TelemetricWebElement(super.findElementByTagName(using), this);
+	}
+
+	@Override
+	public WebElement findElementByXPath(String using) {
+		return new TelemetricWebElement(super.findElementByXPath(using), this);
+	}
+
+	@Override
+	public List<WebElement> findElements(By by) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElements(by)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public List<WebElement> findElementsByClassName(String using) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElementsByClassName(using)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public List<WebElement> findElementsByCssSelector(String using) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElementsByCssSelector(using)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public List<WebElement> findElementsById(String using) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElementsById(using)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public List<WebElement> findElementsByLinkText(String using) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElementsByLinkText(using)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public List<WebElement> findElementsByName(String using) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElementsByName(using)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public List<WebElement> findElementsByPartialLinkText(String using) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElementsByPartialLinkText(using)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public List<WebElement> findElementsByTagName(String using) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElementsByTagName(using)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public List<WebElement> findElementsByXPath(String using) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElementsByXPath(using)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public void measurePerformance(String label) {
+		Performance performance = Performance.parseJson(executeJavaScript(SCRIPT));
+		performance.setBrowser(getCapabilities().getBrowserName());
+		performance.setLabel(label);
+		measure.addPerformance(performance);
+	}
+
+	@Override
+	public void setPerformanceMeasure(PerformanceTelemetry m) {
+		this.measure = m;
+	}
+}

--- a/pitalium/src/main/java/com/htmlhifive/pitalium/core/selenium/TelemetricSelendroidDriver.java
+++ b/pitalium/src/main/java/com/htmlhifive/pitalium/core/selenium/TelemetricSelendroidDriver.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright (C) 2015-2017 NS Solutions Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.htmlhifive.pitalium.core.selenium;
+
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import com.htmlhifive.pitalium.core.model.Performance;
+import com.htmlhifive.pitalium.core.rules.PerformanceTelemetry;
+
+/**
+ * Android端末で利用する{@link org.openqa.selenium.WebDriver}。旧端末（Appium + Selendroid）向け。
+ */
+class TelemetricSelendroidDriver extends PtlSelendroidDriver implements TelemetricWebDriver {
+	private PerformanceTelemetry measure;
+
+	/**
+	 * コンストラクタ
+	 * 
+	 * @param remoteAddress RemoteWebDriverServerのアドレス
+	 * @param capabilities Capability
+	 */
+	TelemetricSelendroidDriver(URL remoteAddress, PtlCapabilities capabilities) {
+		super(remoteAddress, capabilities);
+	}
+
+	@Override
+	public void get(String url) {
+		measurePerformance(null);
+		super.get(url);
+	}
+
+	@Override
+	public WebElement findElement(By by) {
+		return new TelemetricWebElement(super.findElement(by), this);
+	}
+
+	@Override
+	public WebElement findElementByClassName(String using) {
+		return new TelemetricWebElement(super.findElementByClassName(using), this);
+	}
+
+	@Override
+	public WebElement findElementByCssSelector(String using) {
+		return new TelemetricWebElement(super.findElementByCssSelector(using), this);
+	}
+
+	@Override
+	public WebElement findElementById(String using) {
+		return new TelemetricWebElement(super.findElementById(using), this);
+	}
+
+	@Override
+	public WebElement findElementByLinkText(String using) {
+		return new TelemetricWebElement(super.findElementByLinkText(using), this);
+	}
+
+	@Override
+	public WebElement findElementByName(String using) {
+		return new TelemetricWebElement(super.findElementByName(using), this);
+	}
+
+	@Override
+	public WebElement findElementByPartialLinkText(String using) {
+		return new TelemetricWebElement(super.findElementByPartialLinkText(using), this);
+	}
+
+	@Override
+	public WebElement findElementByTagName(String using) {
+		return new TelemetricWebElement(super.findElementByTagName(using), this);
+	}
+
+	@Override
+	public WebElement findElementByXPath(String using) {
+		return new TelemetricWebElement(super.findElementByXPath(using), this);
+	}
+
+	@Override
+	public List<WebElement> findElements(By by) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElements(by)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public List<WebElement> findElementsByClassName(String using) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElementsByClassName(using)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public List<WebElement> findElementsByCssSelector(String using) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElementsByCssSelector(using)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public List<WebElement> findElementsById(String using) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElementsById(using)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public List<WebElement> findElementsByLinkText(String using) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElementsByLinkText(using)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public List<WebElement> findElementsByName(String using) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElementsByName(using)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public List<WebElement> findElementsByPartialLinkText(String using) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElementsByPartialLinkText(using)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public List<WebElement> findElementsByTagName(String using) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElementsByTagName(using)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public List<WebElement> findElementsByXPath(String using) {
+		List<WebElement> elements = new ArrayList<WebElement>();
+		for (WebElement element : super.findElementsByXPath(using)) {
+			elements.add(new TelemetricWebElement(element, this));
+		}
+		return elements;
+	}
+
+	@Override
+	public void measurePerformance(String label) {
+		Performance performance = Performance.parseJson(executeJavaScript(SCRIPT));
+		performance.setBrowser(getCapabilities().getBrowserName());
+		performance.setLabel(label);
+		measure.addPerformance(performance);
+	}
+
+	@Override
+	public void setPerformanceMeasure(PerformanceTelemetry m) {
+		this.measure = m;
+	}
+
+}

--- a/pitalium/src/main/java/com/htmlhifive/pitalium/core/selenium/TelemetricWebDriver.java
+++ b/pitalium/src/main/java/com/htmlhifive/pitalium/core/selenium/TelemetricWebDriver.java
@@ -1,0 +1,86 @@
+package com.htmlhifive.pitalium.core.selenium;
+
+import com.htmlhifive.pitalium.core.rules.PerformanceTelemetry;
+
+/**
+ * 性能測定機能を持つWebDriverのインターフェイス。
+ */
+public interface TelemetricWebDriver {
+	//@formatter:off
+	// CHECKSTYLE:OFF
+	/**
+	 * ブラウザのPerformance API等を実行し
+	 * {@link com.htmlhifive.pitalium.core.model.Performance}のJSON文字列表現を取得するJavaScript
+	 */
+	String SCRIPT =
+			"if(typeof JSON === 'undefined') {" +
+			// JSON.stringifyが実装されていない場合のための実装
+	        "    function stringify(obj) {" +
+			"        if (typeof obj === 'number') {" +
+			"            return String(obj);" +
+			"        } else if (typeof obj === 'string') {" +
+			"            return '\"' + jsonEscape(obj) + '\"';" +
+			"        } else if (obj instanceof Array) {" +
+			"            return stringifyArray(obj);" +
+			"        }" +
+			"        return stringifyObject(obj);" +
+			"    }" +
+			"    function jsonEscape(str) {" +
+			"        return str.replace(/\\\\/g, '\\\\\\\\')" +
+			"            .replace(/\"/g, '\\\\\"')" +
+			"            .replace(/\\//g, '\\\\/');" +
+			"    }" +
+			"    function stringifyObject(obj) {" +
+			"        var ret = [];" +
+			"        for (var i in obj) {" +
+			"            ret.push('\"' + i + '\":' + stringify(obj[i]));" +
+			"        }" +
+			"        return '{' + ret.join(',') + '}';" +
+			"    }" +
+			"    function stringifyArray(arr) {" +
+			"        var ret = [];" +
+			"        for (var i in arr) {" +
+			"            ret.push(stringify(arr[i]));" +
+			"        }" +
+			"        return '[' + ret.join(',') + ']';" +
+			"    }" +
+			"    JSON = {" +
+			"        stringify: stringify" +
+			"    };" +
+			"}" +
+			"return JSON.stringify({" +
+			"    navigationTiming: performance && performance.timing || {}," +
+			"    resourceTimings: (" +
+			"                        performance" +
+			"                        && performance.getEntriesByType" +
+			"                        && performance.getEntriesByType('resource')" +
+			"                     ) || []," +
+			"    marks: (" +
+			"              performance" +
+			"              && performance.getEntriesByType" +
+			"              && performance.getEntriesByType('mark')" +
+			"           ) || []," +
+			"    measures: (" +
+			"                 performance " +
+			"                 && performance.getEntriesByType" +
+			"                 && performance.getEntriesByType('measure')" +
+			"              ) || []," +
+			"    url: window.location.toString()" +
+			"});";
+	// CHECKSTYLE:ON
+	//@formatter:on
+
+	/**
+	 * 性能を測定します。
+	 * 
+	 * @param label 性能測定結果のラベル
+	 */
+	void measurePerformance(String label);
+
+	/**
+	 * 性能測定結果の記録先となる{@link com.htmlhifive.pitalium.core.rules.PerformanceTelemetry}を設定します。
+	 * 
+	 * @param telemetry 性能測定結果の記録先
+	 */
+	void setPerformanceMeasure(PerformanceTelemetry telemetry);
+}

--- a/pitalium/src/main/java/com/htmlhifive/pitalium/core/selenium/TelemetricWebElement.java
+++ b/pitalium/src/main/java/com/htmlhifive/pitalium/core/selenium/TelemetricWebElement.java
@@ -1,0 +1,394 @@
+package com.htmlhifive.pitalium.core.selenium;
+
+import java.util.List;
+import java.util.Map;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.Dimension;
+import org.openqa.selenium.OutputType;
+import org.openqa.selenium.Point;
+import org.openqa.selenium.Rectangle;
+import org.openqa.selenium.WebDriverException;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.interactions.internal.Coordinates;
+import org.openqa.selenium.remote.FileDetector;
+import org.openqa.selenium.remote.RemoteWebDriver;
+
+import com.google.common.base.Supplier;
+
+/**
+ * 性能測定機能を持つ{@link PtlWebElement}の実装クラス。 click、submit時に性能測定を行う。
+ */
+public class TelemetricWebElement extends PtlWebElement implements WebElement {
+	private TelemetricWebDriver driver;
+	private PtlWebElement element;
+
+	/**
+	 * コンストラクタ
+	 * 
+	 * @param element 動作を委譲するPtlWebElement
+	 * @param driver 性能測定を行うTelemetricWebDriver
+	 */
+	TelemetricWebElement(WebElement element, TelemetricWebDriver driver) {
+		this.element = (PtlWebElement) element;
+		this.driver = driver;
+	}
+
+	@Override
+	public void clear() {
+		element.clear();
+	}
+
+	@Override
+	public void click() {
+		driver.measurePerformance(null);
+		element.click();
+	}
+
+	@Override
+	public WebElement findElement(By arg0) {
+		return element.findElement(arg0);
+	}
+
+	@Override
+	public List<WebElement> findElements(By arg0) {
+		return element.findElements(arg0);
+	}
+
+	@Override
+	public String getAttribute(String arg0) {
+		return element.getAttribute(arg0);
+	}
+
+	@Override
+	public String getCssValue(String arg0) {
+		return element.getCssValue(arg0);
+	}
+
+	@Override
+	public Point getLocation() {
+		return element.getLocation();
+	}
+
+	@Override
+	public Rectangle getRect() {
+		return element.getRect();
+	}
+
+	@Override
+	public <X> X getScreenshotAs(OutputType<X> arg0) throws WebDriverException {
+		return element.getScreenshotAs(arg0);
+	}
+
+	@Override
+	public Dimension getSize() {
+		return element.getSize();
+	}
+
+	@Override
+	public String getTagName() {
+		return element.getTagName();
+	}
+
+	@Override
+	public String getText() {
+		return element.getText();
+	}
+
+	@Override
+	public boolean isDisplayed() {
+		return element.isDisplayed();
+	}
+
+	@Override
+	public boolean isEnabled() {
+		return element.isEnabled();
+	}
+
+	@Override
+	public boolean isSelected() {
+		return element.isSelected();
+	}
+
+	@Override
+	public void sendKeys(CharSequence... arg0) {
+		element.sendKeys(arg0);
+	}
+
+	@Override
+	public void submit() {
+		driver.measurePerformance(null);
+		element.submit();
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		return element.equals(obj);
+	}
+
+	@Override
+	public void executeInFrame(Runnable doInFrame) {
+		element.executeInFrame(doInFrame);
+	}
+
+	@Override
+	public <T> T executeInFrame(Supplier<T> doInFrame) {
+		return element.executeInFrame(doInFrame);
+	}
+
+	@Override
+	public void executeInFrame(WebElement frameElement, Runnable doInFrame) {
+		element.executeInFrame(frameElement, doInFrame);
+	}
+
+	@Override
+	public <T> T executeInFrame(WebElement frameElement, Supplier<T> doInFrame) {
+		return element.executeInFrame(frameElement, doInFrame);
+	}
+
+	@Override
+	public WebElement findElementByClassName(String using) {
+		return element.findElementByClassName(using);
+	}
+
+	@Override
+	public WebElement findElementByCssSelector(String using) {
+		return element.findElementByCssSelector(using);
+	}
+
+	@Override
+	public WebElement findElementById(String using) {
+		return element.findElementById(using);
+	}
+
+	@Override
+	public WebElement findElementByLinkText(String using) {
+		return element.findElementByLinkText(using);
+	}
+
+	@Override
+	public WebElement findElementByName(String using) {
+		return element.findElementByName(using);
+	}
+
+	@Override
+	public WebElement findElementByPartialLinkText(String using) {
+		return element.findElementByPartialLinkText(using);
+	}
+
+	@Override
+	public WebElement findElementByTagName(String using) {
+		return element.findElementByTagName(using);
+	}
+
+	@Override
+	public WebElement findElementByXPath(String using) {
+		return element.findElementByXPath(using);
+	}
+
+	@Override
+	public List<WebElement> findElementsByClassName(String using) {
+		return element.findElementsByClassName(using);
+	}
+
+	@Override
+	public List<WebElement> findElementsByCssSelector(String using) {
+		return element.findElementsByCssSelector(using);
+	}
+
+	@Override
+	public List<WebElement> findElementsById(String using) {
+		return element.findElementsById(using);
+	}
+
+	@Override
+	public List<WebElement> findElementsByLinkText(String using) {
+		return element.findElementsByLinkText(using);
+	}
+
+	@Override
+	public List<WebElement> findElementsByName(String using) {
+		return element.findElementsByName(using);
+	}
+
+	@Override
+	public List<WebElement> findElementsByPartialLinkText(String using) {
+		return element.findElementsByPartialLinkText(using);
+	}
+
+	@Override
+	public List<WebElement> findElementsByTagName(String using) {
+		return element.findElementsByTagName(using);
+	}
+
+	@Override
+	public List<WebElement> findElementsByXPath(String using) {
+		return element.findElementsByXPath(using);
+	}
+
+	@Override
+	public PtlWebElement getFrameParent() {
+		return element.getFrameParent();
+	}
+
+	@Override
+	public WebElementBorderWidth getBorderWidth() {
+		return element.getBorderWidth();
+	}
+
+	@Override
+	public long getClientHeight() {
+		return element.getClientHeight();
+	}
+
+	@Override
+	public long getClientWidth() {
+		return element.getClientWidth();
+	}
+
+	@Override
+	public Coordinates getCoordinates() {
+		return element.getCoordinates();
+	}
+
+	@Override
+	public DoubleValueRect getDoubleValueRect() {
+		return element.getDoubleValueRect();
+	}
+
+	@Override
+	public String getId() {
+		return element.getId();
+	}
+
+	@Override
+	public void setFrameParent(PtlWebElement frameParent) {
+		element.setFrameParent(frameParent);
+	}
+
+	@Override
+	public void setParent(RemoteWebDriver parent) {
+		element.setParent(parent);
+	}
+
+	@Override
+	public PtlWebDriver getWrappedDriver() {
+		return element.getWrappedDriver();
+	}
+
+	@Override
+	public WebElementMargin getMargin() {
+		return element.getMargin();
+	}
+
+	@Override
+	public WebElementPadding getPadding() {
+		return element.getPadding();
+	}
+
+	@Override
+	public void hide() {
+		element.hide();
+	}
+
+	@Override
+	public void show() {
+		element.show();
+	}
+
+	@Override
+	public boolean isVisibilityHidden() {
+		return element.isVisibilityHidden();
+	}
+
+	@Override
+	public int getScrollNum() {
+		return element.getScrollNum();
+	}
+
+	@Override
+	public long getScrollHeight() {
+		return element.getScrollHeight();
+	}
+
+	@Override
+	public long getScrollWidth() {
+		return element.getScrollWidth();
+	}
+
+	@Override
+	public int scrollNext() throws InterruptedException {
+		return element.scrollNext();
+	}
+
+	@Override
+	public void scrollTo(double x, double y) throws InterruptedException {
+		element.scrollTo(x, y);
+	}
+
+	@Override
+	public void hideScrollBar() {
+		element.hideScrollBar();
+	}
+
+	@Override
+	public String[] getOverflowStatus() {
+		return element.getOverflowStatus();
+	}
+
+	@Override
+	public String getResizeStatus() {
+		return element.getResizeStatus();
+	}
+
+	@Override
+	public int hashCode() {
+		return element.hashCode();
+	}
+
+	@Override
+	public void setOverflowStatus(String xStatus, String yStatus) {
+		element.setOverflowStatus(xStatus, yStatus);
+	}
+
+	@Override
+	public boolean isBody() {
+		return element.isBody();
+	}
+
+	@Override
+	public boolean isFrame() {
+		return element.isFrame();
+	}
+
+	@Override
+	public void setFileDetector(FileDetector detector) {
+		element.setFileDetector(detector);
+	}
+
+	@Override
+	public void setId(String id) {
+		element.setId(id);
+	}
+
+	@Override
+	public void setNoResizable() {
+		element.setNoResizable();
+	}
+
+	@Override
+	public void setResizeStatus(String status) {
+		element.setResizeStatus(status);
+	}
+
+	@Override
+	public Map<String, Object> toJson() {
+		return element.toJson();
+	}
+
+	@Override
+	public String toString() {
+		return element.toString();
+	}
+
+}

--- a/pitalium/src/main/resources/templates/detail.html
+++ b/pitalium/src/main/resources/templates/detail.html
@@ -1,0 +1,138 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:th="http://www.thymeleaf.org">
+<head>
+    <title></title>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css"/>
+</head>
+<body>
+<div th:each="performance : ${performanceResults}" class="panel panel-default">
+    <div th:text="${performance.label}" class="panel-heading">http://example.com/</div>
+    <div class="panel-body">
+        <div id="1234567890" th:id="${performance.id}" style="height:50%;"></div>
+    </div>
+</div>
+<script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
+<script th:inline="javascript" type="text/javascript">
+/*<![CDATA[*/
+function addNormalizedRow(dataTable, position, name, start, end, origin) {
+    if ((start > 0 || end > 0) && end >= start) {
+        dataTable.addRow([position, name, start - origin, end - origin]);
+    }
+}
+google.charts.load("current", { packages: ["timeline"] });
+
+google.charts.setOnLoadCallback(function(){
+    var performanceResults = /*[[${performanceResults}]]*/ [ { id: '1234567890', navigationTiming: performance.timing, resourceTimings: performance.getEntries('resource'), }, ];
+    for(var j in performanceResults) {
+        var result = performanceResults[j];
+        var container = document.getElementById(result.id);
+        var chart = new google.visualization.Timeline(container);
+        var dataTable = new google.visualization.DataTable();
+        dataTable.addColumn({ type: 'string', id: 'Position' });
+        dataTable.addColumn({ type: 'string', id: 'Name' });
+        dataTable.addColumn({ type: 'number', id: 'Start' });
+        dataTable.addColumn({ type: 'number', id: 'End' });
+        var navigationTiming = result.navigationTiming;
+        dataTable.addRows([
+            ['Navigation', '遷移開始', 0, 0],
+        ]);
+        addNormalizedRow(dataTable, 'Navigation', 'リダイレクト',
+            navigationTiming.redirectStart,
+            navigationTiming.redirectEnd,
+            navigationTiming.navigationStart
+        );
+        addNormalizedRow(dataTable, 'Navigation', '名前解決',
+            navigationTiming.domainLookupStart,
+            navigationTiming.domainLookupEnd,
+            navigationTiming.navigationStart
+        );
+        addNormalizedRow(dataTable, 'Navigation', '接続確立',
+            navigationTiming.connectStart,
+            navigationTiming.connectEnd,
+            navigationTiming.navigationStart
+        );
+        addNormalizedRow(dataTable, 'Navigation', 'バックエンド',
+            navigationTiming.requestStart,
+            navigationTiming.responseStart,
+            navigationTiming.navigationStart
+        );
+        addNormalizedRow(dataTable, 'Navigation', 'ダウンロード',
+            navigationTiming.responseStart,
+            navigationTiming.responseEnd,
+            navigationTiming.navigationStart
+        );
+        addNormalizedRow(dataTable, 'Navigation', 'DOMContentLoadedイベント',
+            navigationTiming.domContentLoadedEventStart,
+            navigationTiming.domContentLoadedEventEnd,
+            navigationTiming.navigationStart
+        );
+        addNormalizedRow(dataTable, 'Navigation', 'Loadイベント',
+            navigationTiming.loadEventStart,
+            navigationTiming.loadEventEnd,
+            navigationTiming.navigationStart
+        );
+        for(var i in result.marks) {
+            var mark = result.marks[i];
+            dataTable.addRow([
+                'marks',
+                mark.name,
+                mark.startTime,
+                mark.startTime
+            ]);
+        }
+        for(var i in result.measures) {
+            var measure = result.measures[i];
+            dataTable.addRow([
+                'measures',
+                measure.name,
+                measure.startTime,
+                measure.startTime + measure.duration
+            ]);
+        }
+        for(var i in result.resourceTimings) {
+            var resourceTiming = result.resourceTimings[i];
+            addNormalizedRow(dataTable, resourceTiming.name, 'リダイレクト',
+                resourceTiming.redirectStart,
+                resourceTiming.redirectEnd,
+                0
+            );
+            addNormalizedRow(dataTable, resourceTiming.name, '名前解決',
+                resourceTiming.redirectStart,
+                resourceTiming.redirectEnd,
+                0
+            );
+            addNormalizedRow(dataTable, resourceTiming.name, '接続確立',
+                resourceTiming.connectStart,
+                resourceTiming.connectEnd,
+                0
+            );
+            addNormalizedRow(dataTable, resourceTiming.name, 'バックエンド',
+                resourceTiming.requestStart,
+                resourceTiming.responseStart,
+                0
+            );
+            if (resourceTiming.responseStart > 0) {
+                addNormalizedRow(dataTable, resourceTiming.name, 'ダウンロード',
+                    resourceTiming.responseStart,
+                    resourceTiming.responseEnd,
+                    0
+                );
+            } else {
+                addNormalizedRow(dataTable, resourceTiming.name, '取得',
+                    resourceTiming.fetchStart,
+                    resourceTiming.responseEnd,
+                    0
+                );
+            }
+        }
+        chart.draw(dataTable, {
+            hAxis: {
+                maxValue: 1000,
+            },
+        });
+    }
+});
+/*]]>*/
+</script>
+</body>
+</html>

--- a/pitalium/src/test/java/com/htmlhifive/pitalium/core/config/EnvironmentConfigTest.java
+++ b/pitalium/src/test/java/com/htmlhifive/pitalium/core/config/EnvironmentConfigTest.java
@@ -53,6 +53,7 @@ public class EnvironmentConfigTest {
 		assertThat(env.getScriptTimeout(), is(10));
 		assertThat(env.getCapabilitiesFilePath(), is("test.json"));
 		assertThat(env.getPersister(), is("test"));
+		assertThat(env.getPerformanceMeasurementMode(), is(PerformanceMeasurementMode.ON));
 		assertThat(env.isDebug(), is(true));
 	}
 
@@ -89,6 +90,7 @@ public class EnvironmentConfigTest {
 		assertThat(config.getCapabilitiesFilePath(), is("capabilities.json"));
 		assertThat(config.getPersister(), is("com.htmlhifive.pitalium.core.io.FilePersister"));
 		assertThat(config.getWebDriverSessionLevel(), is(WebDriverSessionLevel.TEST_CASE));
+		assertThat(config.getPerformanceMeasurementMode(), is(PerformanceMeasurementMode.OFF));
 		assertThat(config.isDebug(), is(false));
 	}
 
@@ -110,6 +112,7 @@ public class EnvironmentConfigTest {
 				.persister("persister")
 				.autoResizeWindow(true)
 				.webDriverSessionLevel(WebDriverSessionLevel.GLOBAL)
+				.performanceMeasurementMode(PerformanceMeasurementMode.ON)
 				.debug(true)
 				.build();
 //@formatter:on
@@ -125,6 +128,7 @@ public class EnvironmentConfigTest {
 		assertThat(config.getCapabilitiesFilePath(), is("cap.json"));
 		assertThat(config.getPersister(), is("persister"));
 		assertThat(config.getWebDriverSessionLevel(), is(WebDriverSessionLevel.GLOBAL));
+		assertThat(config.getPerformanceMeasurementMode(), is(PerformanceMeasurementMode.ON));
 		assertThat(config.isDebug(), is(true));
 	}
 

--- a/pitalium/src/test/resources/com/htmlhifive/pitalium/core/config/EnvironmentConfigTest_allProperties.json
+++ b/pitalium/src/test/resources/com/htmlhifive/pitalium/core/config/EnvironmentConfigTest_allProperties.json
@@ -9,5 +9,6 @@
 	"capabilitiesFilePath": "test.json",
 	"persister": "test",
 	"autoResizeWindow": true,
+	"performanceMeasurementMode": "ON",
 	"debug": true
 }


### PR DESCRIPTION
ページ遷移したときなどにWeb API経由でブラウザから性能情報を取得する機能を追加しました。
これにより、「スクリーンショットは一致していても時間がかかりすぎている」といった問題がないかどうかもテストできるようになり、使いどころがいっそう増えると考えています。
既存機能を邪魔しないように、設定に「性能測定モード」を追加し、これを明示的にONにした時のみ機能を利用できるようになる実装にしました。

ご確認のほど、よろしくお願いいたします。
パッケージの分け方、追加すべきテストなどございましたら、ご教示ください。

#### 使い方

本機能は `PtlTestBase` を拡張した `TelemetricTestBase` を基底クラスとしてテストクラスを記述する使い方を想定しています。
具体的な書き方は https://github.com/iijimakazuyuki/hifive-pitalium-samples/commit/7b779efbaf407c855d4bf2d7904bdbcdf4089cb1 をご覧ください。
`TelemetricTestBase` は `PtlTestBase` と同様、Ruleクラスでテスト結果の出力を行っており、
スクリーンショットのフォルダ内に
`testCaptureTop_performance_WINDOWS_chrome.html`
というような名前のレポートがテストメソッド単位で出力されるようになります。
ここには各ページ遷移時の性能情報が記録されています。

ちなみに、このレポートはThymeleafテンプレートを用いており、ユーザが差替可能です。
具体的な差替方法は https://github.com/iijimakazuyuki/hifive-pitalium-samples/commit/458ef4e87ecee80a7b25c019a3a0ce3ee5079284 をご覧ください。

このレポートは、下記メソッド実行時に性能情報が追記されます。
- `WebDriver#get()`
- `WebElement#click()`
- `WebElement#submit()`

なお、上記メソッドで検知できないタイミングの場合は、`PerformanceTelemetry#measurePerformance()` を実行すれば、手動で性能情報を取得できます。
